### PR TITLE
montre le changement d'impôt sur le revenu induit par la réforme via …

### DIFF
--- a/components/SimpleCard.jsx
+++ b/components/SimpleCard.jsx
@@ -61,6 +61,9 @@ const BlueTooltip = withStyles(theme => ({
       maxWidth: 220,
       fontSize: theme.typography.pxToRem(12),
     },
+    tooltipPlacementBottom: {
+        margin: '0px 0',
+      },
   }))(Tooltip);
 
 class SimpleCard extends React.Component {
@@ -199,14 +202,6 @@ class SimpleCard extends React.Component {
                         </div>
                     </div>
                     <Divider/>
-                        <BlueTooltip
-                            key="gain"
-                            placement="bottom"
-                            title={"Soit "+(-impots_apres+impots_avant>0?"+":"-")+
-                            Math.round(Math.abs(-impots_apres+impots_avant))+"€/an"}
-                            enterDelay={300}
-                            leaveDelay={200}
-                            >
                     <div className={classes.div}>
                         <Typography className={classes.legende}>Impôt sur le revenu par an</Typography>
                         <Typography inline={true} variant="h3" color="primary" gutterBottom>
@@ -216,20 +211,33 @@ class SimpleCard extends React.Component {
                             €
                         </Typography>
                         <br />
-                        {loading ? (
-                            <CircularProgress color="secondary" />
-                        ) : (
-                            <>
-                                <Typography inline={true} variant="h3" color="secondary" gutterBottom>
-                                    {-impots_apres}
-                                </Typography>
-                                <Typography inline={true} variant="h5" color="secondary" gutterBottom>
-                                    €
-                                </Typography>
-                            </>
-                        )}
+                        <BlueTooltip
+                            key="gain"
+                            placement="bottom-start"
+                            title=<React.Fragment>
+                            {"Soit "}<b>{(-impots_apres+impots_avant>0?"+":"-")+
+                            Math.round(Math.abs(-impots_apres+impots_avant))+"€"}</b>
+                            {"/an"}
+                            </React.Fragment>
+                            enterDelay={300}
+                            leaveDelay={200}
+                            >
+                            <div>
+                            {loading ? (
+                                <CircularProgress color="secondary" />
+                            ) : (
+                                <>
+                                    <Typography inline={true} variant="h3" color="secondary" gutterBottom>
+                                        {-impots_apres}
+                                    </Typography>
+                                    <Typography inline={true} variant="h5" color="secondary" gutterBottom>
+                                        €
+                                    </Typography>
+                                </>
+                            )}
+                            </div>
+                        </BlueTooltip>
                     </div>
-                    </BlueTooltip>
                 </CardContent>
             </Card>
         )

--- a/components/SimpleCard.jsx
+++ b/components/SimpleCard.jsx
@@ -54,6 +54,15 @@ function numberToRevenuparmois(rev) {
     return `${rev}€/mois`
 }
 
+const BlueTooltip = withStyles(theme => ({
+    tooltip: {
+      backgroundColor: '#00a3ff',
+      color: '#ffffff',
+      maxWidth: 220,
+      fontSize: theme.typography.pxToRem(12),
+    },
+  }))(Tooltip);
+
 class SimpleCard extends React.Component {
     constructor(props) {
         super(props)
@@ -190,6 +199,14 @@ class SimpleCard extends React.Component {
                         </div>
                     </div>
                     <Divider/>
+                        <BlueTooltip
+                            key="gain"
+                            placement="bottom"
+                            title={"Soit "+(-impots_apres+impots_avant>0?"+":"-")+
+                            Math.round(Math.abs(-impots_apres+impots_avant))+"€/an"}
+                            enterDelay={300}
+                            leaveDelay={200}
+                            >
                     <div className={classes.div}>
                         <Typography className={classes.legende}>Impôt sur le revenu par an</Typography>
                         <Typography inline={true} variant="h3" color="primary" gutterBottom>
@@ -212,6 +229,7 @@ class SimpleCard extends React.Component {
                             </>
                         )}
                     </div>
+                    </BlueTooltip>
                 </CardContent>
             </Card>
         )


### PR DESCRIPTION
…un tooltip au dessus de la zone de résultat

cf Trello card : https://trello.com/c/U54mKvo7/123-simplecard-tooltip-impact-r%C3%A9forme

@DorineLam Checke notamment les points suivants : 
- J'ai pas trouvé le figma correspondant, dis moi si j'ai loupé de gros trucs sur la typo
- Maintenant qu'on a ce tooltip de ouf, est ce qu'on veut que les autres tooltips soient dans le même style (i.e. bleus) ? 
- Pour l'instant j'ai activé le tooltip sur toute la zone de résultat (i.e. même quand le mec hover le montant "avant réforme" le tooltip apparaît, j'étais pas sûr de la zone que tu voulais et ça me semblait plus simple à trouver