### PR TITLE
Extension modifiables

### DIFF
--- a/components/Article.jsx
+++ b/components/Article.jsx
@@ -215,9 +215,10 @@ class Article extends React.Component {
     }
 
     baseOutputInput(name){
-        console.log(name)
-        const baseval=eval("this.state.basecode.impot_revenu."+name)
-        const newval=eval("this.state.reforme.impot_revenu."+name)
+        var regextaux=RegExp("taux")
+        const tx=regextaux.test(name)
+        const baseval=eval("this.state.basecode.impot_revenu."+name) * (tx?100:1)
+        const newval=eval("this.state.reforme.impot_revenu."+name) * (tx?100:1)
         return (<><OutputField value={baseval} style={style.VarCodeexistant} />
                 <InputField
                     value={newval}
@@ -229,11 +230,6 @@ class Article extends React.Component {
     }
 
     alinea2ext() {
-        const scelib = this.state.reforme.impot_revenu.decote.seuil_celib
-        const scouple = this.state.reforme.impot_revenu.decote.seuil_couple
-        const basescelib = this.state.basecode.impot_revenu.decote.seuil_celib
-        const basescouple = this.state.basecode.impot_revenu.decote.seuil_couple
-
         return (
             <Typography variant="body2" color="inherit">
                ... ne peut excéder 
@@ -264,6 +260,20 @@ class Article extends React.Component {
             {this.baseOutputInput("plafond_qf.reduc_postplafond_veuf")}€ pour cette part supplémentaire lorsque la réduction de leur cotisation d'impôt est plafonnée
             en application du premier alinéa du présent 2. Cette réduction d'impôt ne peut toutefois excéder
             l'augmentation de la cotisation d'impôt résultant du plafonnement.
+        </Typography>
+        )
+    }
+
+    alinea3ext(){
+
+        return (
+        <Typography variant="body2" color="inherit">
+        ...{this.baseOutputInput("plafond_qf.abat_dom.taux_GuadMarReu")}%, dans la limite de 
+        {this.baseOutputInput("plafond_qf.abat_dom.plaf_GuadMarReu")}€ pour les contribuables domiciliés 
+        dans les départements de la Guadeloupe, de la Martinique et de la Réunion ; cette réduction est
+        égale à {this.baseOutputInput("plafond_qf.abat_dom.taux_GuyMay")}%, dans la limite de 
+        {this.baseOutputInput("plafond_qf.abat_dom.plaf_GuyMay")}€, pour les contribuables
+        domiciliés dans les départements de la Guyane et de Mayotte ;
         </Typography>
         )
     }
@@ -493,17 +503,12 @@ class Article extends React.Component {
                     >
                         <Typography variant="body2" color="inherit">
                             3. Le montant de l'impôt résultant de l'application des dispositions
-                            précédentes est réduit de 30 %, dans la limite de 2 450 €...
+                            précédentes est réduit de...
                         </Typography>
                     </ExpansionPanelSummary>
 
                     <ExpansionPanelDetails style={styleExpansionpanel}>
-                        <Typography variant="body2" color="inherit">
-                            ...pour les contribuables domiciliés dans les départements de la
-                            Guadeloupe, de la Martinique et de la Réunion ; cette réduction est
-                            égale à 40 %, dans la limite de 4 050 €, pour les contribuables
-                            domiciliés dans les départements de la Guyane et de Mayotte ;
-                        </Typography>
+                    {this.alinea3ext()}
                     </ExpansionPanelDetails>
                 </ExpansionPanel>
 

--- a/components/Article.jsx
+++ b/components/Article.jsx
@@ -30,6 +30,12 @@ const style = {
         lineHeight: "10px",
         padding: "8px",
     },
+    VarCodeNew: {
+        fontWeight: "bold",
+        color: "#00A3FF",
+        lineHeight: "10px",
+        padding: "8px",
+    },
     InputSeuil: {
         fontSize: "20px",
         width: "70px",
@@ -236,6 +242,20 @@ class Article extends React.Component {
         return (<OutputField value={baseval} style={style.VarCodeexistant} />)
     }
 
+    formulaOutputInput(name){
+        const baseval=eval("this.state.basecode.impot_revenu."+name) 
+        const newval=eval("this.state.reforme.impot_revenu."+name)
+        return (<><OutputField value={baseval} style={style.VarCodeexistant} />
+        <OutputField value={newval} style={style.VarCodeNew} /></>)
+    }
+
+    formulaOutputInputCombiLin(name1,fact1,name2,fact2){
+        const baseval=eval("this.state.basecode.impot_revenu."+name1 + "* fact1 + this.state.basecode.impot_revenu." + name2 +" * fact2") 
+        const newval=eval("this.state.reforme.impot_revenu."+name1 + "* fact1 + this.state.reforme.impot_revenu." + name2 +" * fact2") 
+        return (<><OutputField value={baseval} style={style.VarCodeexistant} />
+        <OutputField value={newval} style={style.VarCodeNew} /></>)
+    }
+
     alinea2ext() {
         return (
             <Typography variant="body2" color="inherit">
@@ -324,11 +344,12 @@ class Article extends React.Component {
         return (
         <Typography variant="body2" color="inherit">
         ...au sixième alinéa du présent b pour les contribuables dont le montant des revenus du foyer fiscal, 
-        au sens du 1° du IV de l'article 1417, est inférieur à 21 037 €, pour la première part de 
-        quotient familial des personnes célibataires, veuves ou divorcées, et à 42 074 €, pour les deux
+        au sens du 1° du IV de l'article 1417, est inférieur à {this.baseOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil2")} €, pour la première part de 
+        quotient familial des personnes célibataires, veuves ou divorcées, et à 
+        {this.formulaOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil2 * 2")}€, pour les deux
          premières parts de quotient familial des personnes soumises à une imposition commune. Ces seuils 
-         sont majorés de 3 797 € pour chacune des demi-parts suivantes et de la moitié de ce montant pour 
-         chacun des quarts de part suivants.
+         sont majorés de {this.baseOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil_maj_enf")}€ 
+         pour chacune des demi-parts suivantes et de la moitié de ce montant pour chacun des quarts de part suivants.
         <br/>
         Pour l'application des seuils mentionnés au premier alinéa du présent b, le montant des revenus du foyer fiscal est majoré :
         <br/>
@@ -348,18 +369,20 @@ class Article extends React.Component {
           a du 2 ter de l'article 200 A pour l'application de la seconde phrase du 3° du même a.
         <br/>
         Le taux de la réduction prévue au premier alinéa du présent b est de 20 %. Toutefois, pour les contribuables 
-        dont les revenus du foyer fiscal, au sens du 1° du IV de l'article 1417, excèdent 18 985 €, pour la première
-         part de quotient familial des personnes célibataires, veuves ou divorcées, ou 37 970 €, pour les deux premières
+        dont les revenus du foyer fiscal, au sens du 1° du IV de l'article 1417, excèdent {this.baseOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil1")} €, pour la première
+         part de quotient familial des personnes célibataires, veuves ou divorcées, ou {this.formulaOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil1 * 2")}€, pour les deux premières
         parts de quotient familial des personnes soumises à une imposition commune, ces seuils étant majorés le cas
         échéant dans les conditions prévues au même premier alinéa, le taux de la réduction d'impôt est égal à
-         20 % multiplié par le rapport entre :
+        {this.baseOutputInput("plafond_qf.reduction_ss_condition_revenus.taux")}% multiplié par le rapport entre :
         <br/>
-        – au numérateur, la différence entre 21 037 €, pour les personnes célibataires, veuves ou divorcées, ou 
-        42 074 €, pour les personnes soumises à une imposition commune, ces seuils étant majorés le cas échéant
+        – au numérateur, la différence entre {this.formulaOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil2")}€, 
+        pour les personnes célibataires, veuves ou divorcées, ou 
+        {this.formulaOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil2 * 2")}€, pour les personnes soumises à une imposition commune, ces seuils étant majorés le cas échéant
          dans les conditions prévues audit premier alinéa, et le montant des revenus mentionnés au troisième alinéa 
          du présent b, et ;
         <br/>
-        – au dénominateur, 2 052 €, pour les personnes célibataires, veuves ou divorcées, ou 4 104 €, pour les
+        – au dénominateur, {this.formulaOutputInputCombiLin("plafond_qf.reduction_ss_condition_revenus.seuil2",1,"plafond_qf.reduction_ss_condition_revenus.seuil1",-1)}€, 
+        pour les personnes célibataires, veuves ou divorcées, ou {this.formulaOutputInputCombiLin("plafond_qf.reduction_ss_condition_revenus.seuil2",2,"plafond_qf.reduction_ss_condition_revenus.seuil1",-2)}€, pour les
          personnes soumises à une imposition commune.
         <br/>
         Les montants de revenus mentionnés au présent b sont révisés chaque année dans la même proportion que la limite

--- a/components/Article.jsx
+++ b/components/Article.jsx
@@ -322,7 +322,7 @@ class Article extends React.Component {
                     name="decote.seuil_celib"
                     style={style.InputSeuil}
                 />
-                € et les trois quarts de son montant pour les contribuables célibataires, divorcés
+                € et les <OutputField value={"trois quarts"} style={style.VarCodeexistant} /> [{this.baseOutputInput("decote.taux")}%] de son montant pour les contribuables célibataires, divorcés
                 ou veufs et de la différence entre
                 <OutputField value={basescouple} style={style.VarCodeexistant} />
                 <InputField

--- a/components/Article.jsx
+++ b/components/Article.jsx
@@ -224,9 +224,16 @@ class Article extends React.Component {
                     value={newval}
                     onChange={this.handleS1Change}
                     name={name}
-                    style={style.InputSeuil}
+                    style={tx?style.InputTaux:style.InputSeuil}
                 />
                 </>)
+    }
+
+    baseOutput(name){
+        var regextaux=RegExp("taux")
+        const tx=regextaux.test(name)
+        const baseval=eval("this.state.basecode.impot_revenu."+name) * (tx?100:1)
+        return (<OutputField value={baseval} style={style.VarCodeexistant} />)
     }
 
     alinea2ext() {
@@ -309,6 +316,56 @@ class Article extends React.Component {
                 € et les trois quarts de son montant pour les contribuables soumis à imposition
                 commune.
             </Typography>
+        )
+    }
+
+    alinea4bext(){
+
+        return (
+        <Typography variant="body2" color="inherit">
+        ...au sixième alinéa du présent b pour les contribuables dont le montant des revenus du foyer fiscal, 
+        au sens du 1° du IV de l'article 1417, est inférieur à 21 037 €, pour la première part de 
+        quotient familial des personnes célibataires, veuves ou divorcées, et à 42 074 €, pour les deux
+         premières parts de quotient familial des personnes soumises à une imposition commune. Ces seuils 
+         sont majorés de 3 797 € pour chacune des demi-parts suivantes et de la moitié de ce montant pour 
+         chacun des quarts de part suivants.
+        <br/>
+        Pour l'application des seuils mentionnés au premier alinéa du présent b, le montant des revenus du foyer fiscal est majoré :
+        <br/>
+        1° Du montant des plus-values, déterminées le cas échéant avant application des abattements pour durée
+         de détention mentionnés au 1 de l'article 150-0 D ou à l'article 150-0 D ter et pour lesquelles il est 
+         mis fin au report d'imposition dans les conditions prévues à l'article 150-0 D bis, dans leur rédaction
+          en vigueur jusqu'au 31 décembre 2013 ;
+          <br/>
+        2° Du montant des plus-values, déterminées le cas échéant avant application des abattements pour durée 
+        de détention mentionnés aux 1 ter ou 1 quater de l'article 150-0 D ou à l'article 150-0 D ter, et des
+         créances mentionnées aux I et II de l'article 167 bis, pour la seule détermination du premier terme de
+         la différence mentionnée au deuxième alinéa du 1 du II bis du même article 167 bis ;
+         <br/>
+        3° Du montant des plus-values mentionnées au I de l'article 150-0 B ter, déterminées le cas échéant avant
+         application de l'abattement pour durée de détention mentionné aux 1 ter ou 1 quater de l'article 150-0
+          D, pour la seule détermination du premier terme de la différence mentionné au deuxième alinéa du 2° du 
+          a du 2 ter de l'article 200 A pour l'application de la seconde phrase du 3° du même a.
+        <br/>
+        Le taux de la réduction prévue au premier alinéa du présent b est de 20 %. Toutefois, pour les contribuables 
+        dont les revenus du foyer fiscal, au sens du 1° du IV de l'article 1417, excèdent 18 985 €, pour la première
+         part de quotient familial des personnes célibataires, veuves ou divorcées, ou 37 970 €, pour les deux premières
+        parts de quotient familial des personnes soumises à une imposition commune, ces seuils étant majorés le cas
+        échéant dans les conditions prévues au même premier alinéa, le taux de la réduction d'impôt est égal à
+         20 % multiplié par le rapport entre :
+        <br/>
+        – au numérateur, la différence entre 21 037 €, pour les personnes célibataires, veuves ou divorcées, ou 
+        42 074 €, pour les personnes soumises à une imposition commune, ces seuils étant majorés le cas échéant
+         dans les conditions prévues audit premier alinéa, et le montant des revenus mentionnés au troisième alinéa 
+         du présent b, et ;
+        <br/>
+        – au dénominateur, 2 052 €, pour les personnes célibataires, veuves ou divorcées, ou 4 104 €, pour les
+         personnes soumises à une imposition commune.
+        <br/>
+        Les montants de revenus mentionnés au présent b sont révisés chaque année dans la même proportion que la limite
+        supérieure de la première tranche du barème de l'impôt sur le revenu. Les montants obtenus sont arrondis, 
+        s'il y a lieu, à l'euro supérieur.
+        </Typography>
         )
     }
 
@@ -473,8 +530,8 @@ class Article extends React.Component {
                 <ExpansionPanel
                     style={style.Typography}
                     square
-                    expanded={expanded === "panel1"}
-                    onChange={this.handleChange("panel1")}
+                    expanded={expanded === "panel2"}
+                    onChange={this.handleChange("panel2")}
                 >
                     <ExpansionPanelSummary
                         style={styleExpansionpanel}
@@ -513,6 +570,26 @@ class Article extends React.Component {
                 </ExpansionPanel>
 
                 {this.alinea4a()}
+                <ExpansionPanel
+                    style={style.Typography}
+                    square
+                    expanded={expanded === "panel4b"}
+                    onChange={this.handleChange("panel4b")}
+                >
+                    <ExpansionPanelSummary
+                        style={styleExpansionpanel}
+                        expandIcon={<ExpandMoreIcon />}
+                    >
+                        <Typography variant="body2" color="inherit">
+                        b. Le montant de l'impôt résultant du a est réduit 
+                        dans les conditions prévues...
+                        </Typography>
+                    </ExpansionPanelSummary>
+
+                    <ExpansionPanelDetails style={styleExpansionpanel}>
+                    {this.alinea4bext()}
+                    </ExpansionPanelDetails>
+                </ExpansionPanel>
             </div>
         )
     }

--- a/components/Article.jsx
+++ b/components/Article.jsx
@@ -9,6 +9,7 @@ import Fab from "@material-ui/core/Fab"
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
 import AddIcon from "@material-ui/icons/Add"
 import DeleteIcon from "@material-ui/icons/Delete"
+const _ = require('lodash');
 
 // attente minimum (si l'usage n'appuye pas sur Entrée) avant qu'une saisie ne déclenche un calcul
 const WAIT_INTERVAL = 1000
@@ -223,8 +224,9 @@ class Article extends React.Component {
     baseOutputInput(name){
         var regextaux=RegExp("taux")
         const tx=regextaux.test(name)
-        const baseval=eval("this.state.basecode.impot_revenu."+name) * (tx?100:1)
-        const newval=eval("this.state.reforme.impot_revenu."+name) * (tx?100:1)
+        const baseval= _.get(this.state.basecode.impot_revenu,name)*(tx?100:1)//eval("this.state.basecode.impot_revenu."+name) * (tx?100:1)
+        const newval=_.get(this.state.reforme.impot_revenu,name)*(tx?100:1)//eval("this.state.reforme.impot_revenu."+name) * (tx?100:1)
+        
         return (<><OutputField value={baseval} style={style.VarCodeexistant} />
                 <InputField
                     value={newval}
@@ -238,22 +240,23 @@ class Article extends React.Component {
     baseOutput(name){
         var regextaux=RegExp("taux")
         const tx=regextaux.test(name)
-        const baseval=eval("this.state.basecode.impot_revenu."+name) * (tx?100:1)
+        const baseval=_.get(this.state.basecode.impot_revenu,name)*(tx?100:1)//eval("this.state.basecode.impot_revenu."+name) * (tx?100:1)
         return (<OutputField value={baseval} style={style.VarCodeexistant} />)
     }
 
     formulaOutputInput(name){
         var regextaux=RegExp("taux")
         const tx=regextaux.test(name)
-        const baseval=eval("this.state.basecode.impot_revenu."+name)  * (tx?100:1)
-        const newval=eval("this.state.reforme.impot_revenu."+name) * (tx?100:1)
+        const baseval= _.get(this.state.basecode.impot_revenu,name)*(tx?100:1)//eval("this.state.basecode.impot_revenu."+name) * (tx?100:1)
+        const newval=_.get(this.state.reforme.impot_revenu,name)*(tx?100:1)//eval("this.state.reforme.impot_revenu."+name) * (tx?100:1)
         return (<><OutputField value={baseval} style={style.VarCodeexistant} />
         <OutputField value={newval} style={style.VarCodeNew} /></>)
     }
 
     formulaOutputInputCombiLin(name1,fact1,name2,fact2){
-        const baseval=eval("this.state.basecode.impot_revenu."+name1 + "* fact1 + this.state.basecode.impot_revenu." + name2 +" * fact2") 
-        const newval=eval("this.state.reforme.impot_revenu."+name1 + "* fact1 + this.state.reforme.impot_revenu." + name2 +" * fact2") 
+        const baseval= _.get(this.state.basecode.impot_revenu,name1)*fact1 + _.get(this.state.basecode.impot_revenu,name2)*fact2 
+        const newval=_.get(this.state.reforme.impot_revenu,name1)*fact1 + _.get(this.state.reforme.impot_revenu,name2)*fact2 
+        
         return (<><OutputField value={baseval} style={style.VarCodeexistant} />
         <OutputField value={newval} style={style.VarCodeNew} /></>)
     }
@@ -401,7 +404,7 @@ class Article extends React.Component {
         const nbt = s.length
         const styleAUtiliser = i > 4 ? style.TypographyNouvelleTranche : style.Typography
         // Part 1
-        if (i == 0) {
+        if (i === 0) {
             return (
                 <Typography key={i} variant="body2" color="inherit" style={styleAUtiliser}>
                     {
@@ -419,7 +422,7 @@ class Article extends React.Component {
             )
         }
         // Last part
-        if (i == nbt) {
+        if (i === nbt) {
             return (
                 <Typography key={i} variant="body2" color="inherit" style={styleAUtiliser}>
                     {"– "}

--- a/components/Article.jsx
+++ b/components/Article.jsx
@@ -9,7 +9,7 @@ import Fab from "@material-ui/core/Fab"
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
 import AddIcon from "@material-ui/icons/Add"
 import DeleteIcon from "@material-ui/icons/Delete"
-const _ = require('lodash');
+import { get } from "lodash/fp"
 
 // attente minimum (si l'usage n'appuye pas sur Entrée) avant qu'une saisie ne déclenche un calcul
 const WAIT_INTERVAL = 1000
@@ -114,7 +114,12 @@ class InputField extends React.Component {
     handleChange(e) {
         clearTimeout(this.timer)
         this.setState({ value: e.target.value })
-        this.timer = setTimeout(this.triggerChange, WAIT_INTERVAL, e.target.value, e.target.name)
+        this.timer = setTimeout(
+            this.triggerChange,
+            WAIT_INTERVAL,
+            e.target.value,
+            e.target.name,
+        )
     }
 
     triggerChange(value, name) {
@@ -158,7 +163,11 @@ class OutputField extends React.Component {
     render() {
         const { value } = this.props
         return (
-            <span inline="true" style={this.props.style} className="output-field">
+            <span
+                inline="true"
+                style={this.props.style}
+                className="output-field"
+            >
                 {value}
             </span>
         )
@@ -187,24 +196,28 @@ class Article extends React.Component {
 
     UpdateBareme = (i, value) => {
         const ref = this.state.reforme
-        const list = this.state.reforme.impot_revenu.bareme.seuils.map((item, j) => {
-            if (j === i) {
-                return value
-            }
-            return item
-        })
+        const list = this.state.reforme.impot_revenu.bareme.seuils.map(
+            (item, j) => {
+                if (j === i) {
+                    return value
+                }
+                return item
+            },
+        )
         ref.impot_revenu.bareme.seuils = list
         this.setState({ reforme: ref })
     }
 
     UpdateTaux = (i, value) => {
         const ref = this.state.reforme
-        const list = this.state.reforme.impot_revenu.bareme.taux.map((item, j) => {
-            if (j === i) {
-                return value
-            }
-            return item
-        })
+        const list = this.state.reforme.impot_revenu.bareme.taux.map(
+            (item, j) => {
+                if (j === i) {
+                    return value
+                }
+                return item
+            },
+        )
         ref.impot_revenu.bareme.taux = list
         this.setState({ reforme: ref })
     }
@@ -221,92 +234,139 @@ class Article extends React.Component {
         this.props.removeTranche(e)
     }
 
-    baseOutputInput(name){
-        var regextaux=RegExp("taux")
-        const tx=regextaux.test(name)
-        const baseval= _.get(this.state.basecode.impot_revenu,name)*(tx?100:1)//eval("this.state.basecode.impot_revenu."+name) * (tx?100:1)
-        const newval=_.get(this.state.reforme.impot_revenu,name)*(tx?100:1)//eval("this.state.reforme.impot_revenu."+name) * (tx?100:1)
-        
-        return (<><OutputField value={baseval} style={style.VarCodeexistant} />
+    baseOutputInput(name) {
+        const regextaux = RegExp("taux")
+        const tx = regextaux.test(name)
+        const baseval = get(this.state.basecode.impot_revenu, name) * (tx ? 100 : 1) // eval("this.state.basecode.impot_revenu."+name) * (tx?100:1)
+        const newval = get(this.state.reforme.impot_revenu, name) * (tx ? 100 : 1) // eval("this.state.reforme.impot_revenu."+name) * (tx?100:1)
+
+        return (
+            <>
+                <OutputField value={baseval} style={style.VarCodeexistant} />
                 <InputField
                     value={newval}
                     onChange={this.handleS1Change}
                     name={name}
-                    style={tx?style.InputTaux:style.InputSeuil}
+                    style={tx ? style.InputTaux : style.InputSeuil}
                 />
-                </>)
+            </>
+        )
     }
 
-    baseOutput(name){
-        var regextaux=RegExp("taux")
-        const tx=regextaux.test(name)
-        const baseval=_.get(this.state.basecode.impot_revenu,name)*(tx?100:1)//eval("this.state.basecode.impot_revenu."+name) * (tx?100:1)
-        return (<OutputField value={baseval} style={style.VarCodeexistant} />)
+    baseOutput(name) {
+        const regextaux = RegExp("taux")
+        const tx = regextaux.test(name)
+        const baseval = get(this.state.basecode.impot_revenu, name) * (tx ? 100 : 1) // eval("this.state.basecode.impot_revenu."+name) * (tx?100:1)
+        return <OutputField value={baseval} style={style.VarCodeexistant} />
     }
 
-    formulaOutputInput(name){
-        var regextaux=RegExp("taux")
-        const tx=regextaux.test(name)
-        const baseval= _.get(this.state.basecode.impot_revenu,name)*(tx?100:1)//eval("this.state.basecode.impot_revenu."+name) * (tx?100:1)
-        const newval=_.get(this.state.reforme.impot_revenu,name)*(tx?100:1)//eval("this.state.reforme.impot_revenu."+name) * (tx?100:1)
-        return (<><OutputField value={baseval} style={style.VarCodeexistant} />
-        <OutputField value={newval} style={style.VarCodeNew} /></>)
+    formulaOutputInput(name) {
+        const regextaux = RegExp("taux")
+        const tx = regextaux.test(name)
+        const baseval = get(this.state.basecode.impot_revenu, name) * (tx ? 100 : 1) // eval("this.state.basecode.impot_revenu."+name) * (tx?100:1)
+        const newval = get(this.state.reforme.impot_revenu, name) * (tx ? 100 : 1) // eval("this.state.reforme.impot_revenu."+name) * (tx?100:1)
+        return (
+            <>
+                <OutputField value={baseval} style={style.VarCodeexistant} />
+                <OutputField value={newval} style={style.VarCodeNew} />
+            </>
+        )
     }
 
-    formulaOutputInputCombiLin(name1,fact1,name2,fact2){
-        const baseval= _.get(this.state.basecode.impot_revenu,name1)*fact1 + _.get(this.state.basecode.impot_revenu,name2)*fact2 
-        const newval=_.get(this.state.reforme.impot_revenu,name1)*fact1 + _.get(this.state.reforme.impot_revenu,name2)*fact2 
-        
-        return (<><OutputField value={baseval} style={style.VarCodeexistant} />
-        <OutputField value={newval} style={style.VarCodeNew} /></>)
+    formulaOutputInputCombiLin(name1, fact1, name2, fact2) {
+        const baseval = get(this.state.basecode.impot_revenu, name1) * fact1
+            + get(this.state.basecode.impot_revenu, name2) * fact2
+        const newval = get(this.state.reforme.impot_revenu, name1) * fact1
+            + get(this.state.reforme.impot_revenu, name2) * fact2
+
+        return (
+            <>
+                <OutputField value={baseval} style={style.VarCodeexistant} />
+                <OutputField value={newval} style={style.VarCodeNew} />
+            </>
+        )
     }
 
     alinea2ext() {
         return (
             <Typography variant="body2" color="inherit">
-               ... ne peut excéder 
-               {this.baseOutputInput("plafond_qf.maries_ou_pacses")}
-               € par demi-part ou la moitié de cette somme par quart de part
-               s'ajoutant à une part pour les contribuables célibataires, divorcés, veufs ou soumis à
-               l'imposition distincte prévue au 4 de l'article 6 et à deux parts pour les contribuables
-               mariés soumis à une imposition commune.
-            
-            Toutefois, pour les contribuables célibataires, divorcés, ou soumis à l'imposition distincte
-            prévue au 4 de l'article 6 qui répondent aux conditions fixées au II de l'article 194,
-            la réduction d'impôt correspondant à la part accordée au titre du premier enfant à charge est limitée
-            à {this.baseOutputInput("plafond_qf.celib_enf")} € Lorsque les contribuables entretiennent uniquement des enfants dont la charge est réputée
-            également partagée entre l'un et l'autre des parents, la réduction d'impôt correspondant à la
-            demi-part accordée au titre de chacun des deux premiers enfants est limitée à la moitié de cette
-            somme. Par dérogation aux dispositions du premier alinéa, la réduction d'impôt résultant de
-            l'application du quotient familial, accordée aux contribuables qui bénéficient des dispositions
-            des a, b et e du 1 de l'article 195, ne peut excéder {this.baseOutputInput("plafond_qf.celib")}€ ;
-            <br/>
-            Les contribuables qui bénéficient d'une demi-part au titre des a, b, c, d, d bis, e et f du 1
-            ainsi que des 2 à 6 de l'article 195 ont droit à une réduction d'impôt égale à {this.baseOutputInput("plafond_qf.reduc_postplafond")}pour
-            chacune de ces demi-parts lorsque la réduction de leur cotisation d'impôt est plafonnée en
-            application du premier alinéa. La réduction d'impôt est égale à la moitié de cette somme lorsque
-            la majoration visée au 2 de l'article 195 est de un quart de part. Cette réduction d'impôt ne peut
-            toutefois excéder l'augmentation de la cotisation d'impôt résultant du plafonnement. Les
-            contribuables veufs ayant des enfants à charge qui bénéficient d'une part supplémentaire de
-            quotient familial en application du I de l'article 194 ont droit à une réduction d'impôt égale à
-            {this.baseOutputInput("plafond_qf.reduc_postplafond_veuf")}€ pour cette part supplémentaire lorsque la réduction de leur cotisation d'impôt est plafonnée
-            en application du premier alinéa du présent 2. Cette réduction d'impôt ne peut toutefois excéder
-            l'augmentation de la cotisation d'impôt résultant du plafonnement.
-        </Typography>
+                ... ne peut excéder
+                {this.baseOutputInput("plafond_qf.maries_ou_pacses")}
+€ par
+                demi-part ou la moitié de cette somme par quart de part
+                s'ajoutant à une part pour les contribuables célibataires,
+                divorcés, veufs ou soumis à l'imposition distincte prévue au 4
+                de l'article 6 et à deux parts pour les contribuables mariés
+                soumis à une imposition commune. Toutefois, pour les
+                contribuables célibataires, divorcés, ou soumis à l'imposition
+                distincte prévue au 4 de l'article 6 qui répondent aux
+                conditions fixées au II de l'article 194, la réduction d'impôt
+                correspondant à la part accordée au titre du premier enfant à
+                charge est limitée à
+                {" "}
+                {this.baseOutputInput("plafond_qf.celib_enf")}
+                {" "}
+€ Lorsque les
+                contribuables entretiennent uniquement des enfants dont la
+                charge est réputée également partagée entre l'un et l'autre des
+                parents, la réduction d'impôt correspondant à la demi-part
+                accordée au titre de chacun des deux premiers enfants est
+                limitée à la moitié de cette somme. Par dérogation aux
+                dispositions du premier alinéa, la réduction d'impôt résultant
+                de l'application du quotient familial, accordée aux
+                contribuables qui bénéficient des dispositions des a, b et e du
+                1 de l'article 195, ne peut excéder
+                {" "}
+                {this.baseOutputInput("plafond_qf.celib")}
+€ ;
+                <br />
+                Les contribuables qui bénéficient d'une demi-part au titre des
+                a, b, c, d, d bis, e et f du 1 ainsi que des 2 à 6 de l'article
+                195 ont droit à une réduction d'impôt égale à
+                {" "}
+                {this.baseOutputInput("plafond_qf.reduc_postplafond")}
+pour
+                chacune de ces demi-parts lorsque la réduction de leur
+                cotisation d'impôt est plafonnée en application du premier
+                alinéa. La réduction d'impôt est égale à la moitié de cette
+                somme lorsque la majoration visée au 2 de l'article 195 est de
+                un quart de part. Cette réduction d'impôt ne peut toutefois
+                excéder l'augmentation de la cotisation d'impôt résultant du
+                plafonnement. Les contribuables veufs ayant des enfants à charge
+                qui bénéficient d'une part supplémentaire de quotient familial
+                en application du I de l'article 194 ont droit à une réduction
+                d'impôt égale à
+                {this.baseOutputInput("plafond_qf.reduc_postplafond_veuf")}
+€
+                pour cette part supplémentaire lorsque la réduction de leur
+                cotisation d'impôt est plafonnée en application du premier
+                alinéa du présent 2. Cette réduction d'impôt ne peut toutefois
+                excéder l'augmentation de la cotisation d'impôt résultant du
+                plafonnement.
+            </Typography>
         )
     }
 
-    alinea3ext(){
-
+    alinea3ext() {
         return (
-        <Typography variant="body2" color="inherit">
-        ...{this.baseOutputInput("plafond_qf.abat_dom.taux_GuadMarReu")}%, dans la limite de 
-        {this.baseOutputInput("plafond_qf.abat_dom.plaf_GuadMarReu")}€ pour les contribuables domiciliés 
-        dans les départements de la Guadeloupe, de la Martinique et de la Réunion ; cette réduction est
-        égale à {this.baseOutputInput("plafond_qf.abat_dom.taux_GuyMay")}%, dans la limite de 
-        {this.baseOutputInput("plafond_qf.abat_dom.plaf_GuyMay")}€, pour les contribuables
-        domiciliés dans les départements de la Guyane et de Mayotte ;
-        </Typography>
+            <Typography variant="body2" color="inherit">
+                ...
+                {this.baseOutputInput("plafond_qf.abat_dom.taux_GuadMarReu")}
+                %, dans la limite de
+                {this.baseOutputInput("plafond_qf.abat_dom.plaf_GuadMarReu")}
+€
+                pour les contribuables domiciliés dans les départements de la
+                Guadeloupe, de la Martinique et de la Réunion ; cette réduction
+                est égale à
+                {" "}
+                {this.baseOutputInput("plafond_qf.abat_dom.taux_GuyMay")}
+%, dans
+                la limite de
+                {this.baseOutputInput("plafond_qf.abat_dom.plaf_GuyMay")}
+€, pour
+                les contribuables domiciliés dans les départements de la Guyane
+                et de Mayotte ;
+            </Typography>
         )
     }
 
@@ -327,9 +387,22 @@ class Article extends React.Component {
                     name="decote.seuil_celib"
                     style={style.InputSeuil}
                 />
-                € et les <OutputField value={"trois quarts"} style={style.VarCodeexistant} /> [{this.baseOutputInput("decote.taux")}%] de son montant pour les contribuables célibataires, divorcés
-                ou veufs et de la différence entre
-                <OutputField value={basescouple} style={style.VarCodeexistant} />
+                € et les
+                {" "}
+                <OutputField
+                    value="trois quarts"
+                    style={style.VarCodeexistant}
+                />
+                {" "}
+                [
+                {this.baseOutputInput("decote.taux")}
+%] de son montant pour les
+                contribuables célibataires, divorcés ou veufs et de la
+                différence entre
+                <OutputField
+                    value={basescouple}
+                    style={style.VarCodeexistant}
+                />
                 <InputField
                     value={scouple}
                     onChange={this.handleS1Change}
@@ -337,62 +410,134 @@ class Article extends React.Component {
                     style={style.InputSeuil}
                 />
                 {" "}
-                € et les <OutputField value={"trois quarts"} style={style.VarCodeexistant} /> [{this.formulaOutputInput("decote.taux")}%] de son montant pour les contribuables soumis à imposition
-                commune.
+                € et les
+                {" "}
+                <OutputField
+                    value="trois quarts"
+                    style={style.VarCodeexistant}
+                />
+                {" "}
+                [
+                {this.formulaOutputInput("decote.taux")}
+%] de son montant pour
+                les contribuables soumis à imposition commune.
             </Typography>
         )
     }
 
-    alinea4bext(){
-
+    alinea4bext() {
         return (
-        <Typography variant="body2" color="inherit">
-        ...au sixième alinéa du présent b pour les contribuables dont le montant des revenus du foyer fiscal, 
-        au sens du 1° du IV de l'article 1417, est inférieur à {this.baseOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil2")} €, pour la première part de 
-        quotient familial des personnes célibataires, veuves ou divorcées, et à 
-        {this.formulaOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil2 * 2")}€, pour les deux
-         premières parts de quotient familial des personnes soumises à une imposition commune. Ces seuils 
-         sont majorés de {this.baseOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil_maj_enf")}€ 
-         pour chacune des demi-parts suivantes et de la moitié de ce montant pour chacun des quarts de part suivants.
-        <br/>
-        Pour l'application des seuils mentionnés au premier alinéa du présent b, le montant des revenus du foyer fiscal est majoré :
-        <br/>
-        1° Du montant des plus-values, déterminées le cas échéant avant application des abattements pour durée
-         de détention mentionnés au 1 de l'article 150-0 D ou à l'article 150-0 D ter et pour lesquelles il est 
-         mis fin au report d'imposition dans les conditions prévues à l'article 150-0 D bis, dans leur rédaction
-          en vigueur jusqu'au 31 décembre 2013 ;
-          <br/>
-        2° Du montant des plus-values, déterminées le cas échéant avant application des abattements pour durée 
-        de détention mentionnés aux 1 ter ou 1 quater de l'article 150-0 D ou à l'article 150-0 D ter, et des
-         créances mentionnées aux I et II de l'article 167 bis, pour la seule détermination du premier terme de
-         la différence mentionnée au deuxième alinéa du 1 du II bis du même article 167 bis ;
-         <br/>
-        3° Du montant des plus-values mentionnées au I de l'article 150-0 B ter, déterminées le cas échéant avant
-         application de l'abattement pour durée de détention mentionné aux 1 ter ou 1 quater de l'article 150-0
-          D, pour la seule détermination du premier terme de la différence mentionné au deuxième alinéa du 2° du 
-          a du 2 ter de l'article 200 A pour l'application de la seconde phrase du 3° du même a.
-        <br/>
-        Le taux de la réduction prévue au premier alinéa du présent b est de 20 %. Toutefois, pour les contribuables 
-        dont les revenus du foyer fiscal, au sens du 1° du IV de l'article 1417, excèdent {this.baseOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil1")} €, pour la première
-         part de quotient familial des personnes célibataires, veuves ou divorcées, ou {this.formulaOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil1 * 2")}€, pour les deux premières
-        parts de quotient familial des personnes soumises à une imposition commune, ces seuils étant majorés le cas
-        échéant dans les conditions prévues au même premier alinéa, le taux de la réduction d'impôt est égal à
-        {this.baseOutputInput("plafond_qf.reduction_ss_condition_revenus.taux")}% multiplié par le rapport entre :
-        <br/>
-        – au numérateur, la différence entre {this.formulaOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil2")}€, 
-        pour les personnes célibataires, veuves ou divorcées, ou 
-        {this.formulaOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil2 * 2")}€, pour les personnes soumises à une imposition commune, ces seuils étant majorés le cas échéant
-         dans les conditions prévues audit premier alinéa, et le montant des revenus mentionnés au troisième alinéa 
-         du présent b, et ;
-        <br/>
-        – au dénominateur, {this.formulaOutputInputCombiLin("plafond_qf.reduction_ss_condition_revenus.seuil2",1,"plafond_qf.reduction_ss_condition_revenus.seuil1",-1)}€, 
-        pour les personnes célibataires, veuves ou divorcées, ou {this.formulaOutputInputCombiLin("plafond_qf.reduction_ss_condition_revenus.seuil2",2,"plafond_qf.reduction_ss_condition_revenus.seuil1",-2)}€, pour les
-         personnes soumises à une imposition commune.
-        <br/>
-        Les montants de revenus mentionnés au présent b sont révisés chaque année dans la même proportion que la limite
-        supérieure de la première tranche du barème de l'impôt sur le revenu. Les montants obtenus sont arrondis, 
-        s'il y a lieu, à l'euro supérieur.
-        </Typography>
+            <Typography variant="body2" color="inherit">
+                ...au sixième alinéa du présent b pour les contribuables dont le
+                montant des revenus du foyer fiscal, au sens du 1° du IV de
+                l'article 1417, est inférieur à
+                {" "}
+                {this.baseOutputInput(
+                    "plafond_qf.reduction_ss_condition_revenus.seuil2",
+                )}
+                {" "}
+                €, pour la première part de quotient familial des personnes
+                célibataires, veuves ou divorcées, et à
+                {this.formulaOutputInput(
+                    "plafond_qf.reduction_ss_condition_revenus.seuil2 * 2",
+                )}
+                €, pour les deux premières parts de quotient familial des
+                personnes soumises à une imposition commune. Ces seuils sont
+                majorés de
+                {" "}
+                {this.baseOutputInput(
+                    "plafond_qf.reduction_ss_condition_revenus.seuil_maj_enf",
+                )}
+                € pour chacune des demi-parts suivantes et de la moitié de ce
+                montant pour chacun des quarts de part suivants.
+                <br />
+                Pour l'application des seuils mentionnés au premier alinéa du
+                présent b, le montant des revenus du foyer fiscal est majoré :
+                <br />
+                1° Du montant des plus-values, déterminées le cas échéant avant
+                application des abattements pour durée de détention mentionnés
+                au 1 de l'article 150-0 D ou à l'article 150-0 D ter et pour
+                lesquelles il est mis fin au report d'imposition dans les
+                conditions prévues à l'article 150-0 D bis, dans leur rédaction
+                en vigueur jusqu'au 31 décembre 2013 ;
+                <br />
+                2° Du montant des plus-values, déterminées le cas échéant avant
+                application des abattements pour durée de détention mentionnés
+                aux 1 ter ou 1 quater de l'article 150-0 D ou à l'article 150-0
+                D ter, et des créances mentionnées aux I et II de l'article 167
+                bis, pour la seule détermination du premier terme de la
+                différence mentionnée au deuxième alinéa du 1 du II bis du même
+                article 167 bis ;
+                <br />
+                3° Du montant des plus-values mentionnées au I de l'article
+                150-0 B ter, déterminées le cas échéant avant application de
+                l'abattement pour durée de détention mentionné aux 1 ter ou 1
+                quater de l'article 150-0 D, pour la seule détermination du
+                premier terme de la différence mentionné au deuxième alinéa du
+                2° du a du 2 ter de l'article 200 A pour l'application de la
+                seconde phrase du 3° du même a.
+                <br />
+                Le taux de la réduction prévue au premier alinéa du présent b
+                est de 20 %. Toutefois, pour les contribuables dont les revenus
+                du foyer fiscal, au sens du 1° du IV de l'article 1417, excèdent
+                {" "}
+                {this.baseOutputInput(
+                    "plafond_qf.reduction_ss_condition_revenus.seuil1",
+                )}
+                {" "}
+                €, pour la première part de quotient familial des personnes
+                célibataires, veuves ou divorcées, ou
+                {" "}
+                {this.formulaOutputInput(
+                    "plafond_qf.reduction_ss_condition_revenus.seuil1 * 2",
+                )}
+                €, pour les deux premières parts de quotient familial des
+                personnes soumises à une imposition commune, ces seuils étant
+                majorés le cas échéant dans les conditions prévues au même
+                premier alinéa, le taux de la réduction d'impôt est égal à
+                {this.baseOutputInput(
+                    "plafond_qf.reduction_ss_condition_revenus.taux",
+                )}
+                % multiplié par le rapport entre :
+                <br />
+– au numérateur, la différence entre
+                {" "}
+                {this.formulaOutputInput(
+                    "plafond_qf.reduction_ss_condition_revenus.seuil2",
+                )}
+                €, pour les personnes célibataires, veuves ou divorcées, ou
+                {this.formulaOutputInput(
+                    "plafond_qf.reduction_ss_condition_revenus.seuil2 * 2",
+                )}
+                €, pour les personnes soumises à une imposition commune, ces
+                seuils étant majorés le cas échéant dans les conditions prévues
+                audit premier alinéa, et le montant des revenus mentionnés au
+                troisième alinéa du présent b, et ;
+                <br />
+– au dénominateur,
+                {" "}
+                {this.formulaOutputInputCombiLin(
+                    "plafond_qf.reduction_ss_condition_revenus.seuil2",
+                    1,
+                    "plafond_qf.reduction_ss_condition_revenus.seuil1",
+                    -1,
+                )}
+                €, pour les personnes célibataires, veuves ou divorcées, ou
+                {" "}
+                {this.formulaOutputInputCombiLin(
+                    "plafond_qf.reduction_ss_condition_revenus.seuil2",
+                    2,
+                    "plafond_qf.reduction_ss_condition_revenus.seuil1",
+                    -2,
+                )}
+                €, pour les personnes soumises à une imposition commune.
+                <br />
+                Les montants de revenus mentionnés au présent b sont révisés
+                chaque année dans la même proportion que la limite supérieure de
+                la première tranche du barème de l'impôt sur le revenu. Les
+                montants obtenus sont arrondis, s'il y a lieu, à l'euro
+                supérieur.
+            </Typography>
         )
     }
 
@@ -406,11 +551,19 @@ class Article extends React.Component {
         // Part 1
         if (i === 0) {
             return (
-                <Typography key={i} variant="body2" color="inherit" style={styleAUtiliser}>
+                <Typography
+                    key={i}
+                    variant="body2"
+                    color="inherit"
+                    style={styleAUtiliser}
+                >
                     {
                         "1. L'impôt est calculé en appliquant à la fraction de chaque part de revenu qui excède"
                     }
-                    <OutputField value={bases[i]} style={style.VarCodeexistant} />
+                    <OutputField
+                        value={bases[i]}
+                        style={style.VarCodeexistant}
+                    />
                     <InputField
                         value={s[i]}
                         onChange={this.handleS1Change}
@@ -424,9 +577,17 @@ class Article extends React.Component {
         // Last part
         if (i === nbt) {
             return (
-                <Typography key={i} variant="body2" color="inherit" style={styleAUtiliser}>
+                <Typography
+                    key={i}
+                    variant="body2"
+                    color="inherit"
+                    style={styleAUtiliser}
+                >
                     {"– "}
-                    <OutputField value={baset[i - 1]} style={style.VarCodeexistant} />
+                    <OutputField
+                        value={baset[i - 1]}
+                        style={style.VarCodeexistant}
+                    />
                     <InputField
                         value={t[i - 1]}
                         onChange={this.handleS1Change}
@@ -441,10 +602,18 @@ class Article extends React.Component {
         }
         // Other parts :
         return (
-            <Typography key={i} variant="body2" color="inherit" style={styleAUtiliser}>
+            <Typography
+                key={i}
+                variant="body2"
+                color="inherit"
+                style={styleAUtiliser}
+            >
                 –
                 {" "}
-                <OutputField value={baset[i - 1]} style={style.VarCodeexistant} />
+                <OutputField
+                    value={baset[i - 1]}
+                    style={style.VarCodeexistant}
+                />
                 <InputField
                     value={t[i - 1]}
                     onChange={this.handleS1Change}
@@ -467,8 +636,6 @@ class Article extends React.Component {
             </Typography>
         )
     }
-
-
 
     render() {
         const { expanded, reforme, basecode } = this.state
@@ -510,13 +677,13 @@ class Article extends React.Component {
 
                     <ExpansionPanelDetails style={styleExpansionpanel}>
                         <Typography variant="body2" color="inherit">
-                            visés à l&#39;article 4 B, il est fait application des règles suivantes
-                            pour le calcul de l&#39;impôt sur le revenu :
+                            visés à l&#39;article 4 B, il est fait application
+                            des règles suivantes pour le calcul de l&#39;impôt
+                            sur le revenu :
                         </Typography>
                     </ExpansionPanelDetails>
                 </ExpansionPanel>
 
-                
                 {articleTranches}
                 <div>
                     <Fab
@@ -567,8 +734,8 @@ class Article extends React.Component {
                         expandIcon={<ExpandMoreIcon />}
                     >
                         <Typography variant="body2" color="inherit">
-                            2. La réduction d&#39;impôt résultant de l&#39;application du quotient
-                            familial ...
+                            2. La réduction d&#39;impôt résultant de
+                            l&#39;application du quotient familial ...
                         </Typography>
                     </ExpansionPanelSummary>
 
@@ -588,13 +755,13 @@ class Article extends React.Component {
                         expandIcon={<ExpandMoreIcon />}
                     >
                         <Typography variant="body2" color="inherit">
-                            3. Le montant de l'impôt résultant de l'application des dispositions
-                            précédentes est réduit de...
+                            3. Le montant de l'impôt résultant de l'application
+                            des dispositions précédentes est réduit de...
                         </Typography>
                     </ExpansionPanelSummary>
 
                     <ExpansionPanelDetails style={styleExpansionpanel}>
-                    {this.alinea3ext()}
+                        {this.alinea3ext()}
                     </ExpansionPanelDetails>
                 </ExpansionPanel>
 
@@ -609,8 +776,9 @@ class Article extends React.Component {
                         expandIcon={<ExpandMoreIcon />}
                     >
                         <Typography variant="body2" color="inherit">
-                        4. a. Le montant de l'impôt résultant de l'application des dispositions précédentes
-                        est diminué, dans...
+                            4. a. Le montant de l'impôt résultant de
+                            l'application des dispositions précédentes est
+                            diminué, dans...
                         </Typography>
                     </ExpansionPanelSummary>
                     <ExpansionPanelDetails style={styleExpansionpanel}>
@@ -628,13 +796,13 @@ class Article extends React.Component {
                         expandIcon={<ExpandMoreIcon />}
                     >
                         <Typography variant="body2" color="inherit">
-                        b. Le montant de l'impôt résultant du a est réduit 
-                        dans les conditions prévues...
+                            b. Le montant de l'impôt résultant du a est réduit
+                            dans les conditions prévues...
                         </Typography>
                     </ExpansionPanelSummary>
 
                     <ExpansionPanelDetails style={styleExpansionpanel}>
-                    {this.alinea4bext()}
+                        {this.alinea4bext()}
                     </ExpansionPanelDetails>
                 </ExpansionPanel>
             </div>

--- a/components/Article.jsx
+++ b/components/Article.jsx
@@ -214,7 +214,61 @@ class Article extends React.Component {
         this.props.removeTranche(e)
     }
 
-    alinea4() {
+    baseOutputInput(name){
+        console.log(name)
+        const baseval=eval("this.state.basecode.impot_revenu."+name)
+        const newval=eval("this.state.reforme.impot_revenu."+name)
+        return (<><OutputField value={baseval} style={style.VarCodeexistant} />
+                <InputField
+                    value={newval}
+                    onChange={this.handleS1Change}
+                    name={name}
+                    style={style.InputSeuil}
+                />
+                </>)
+    }
+
+    alinea2ext() {
+        const scelib = this.state.reforme.impot_revenu.decote.seuil_celib
+        const scouple = this.state.reforme.impot_revenu.decote.seuil_couple
+        const basescelib = this.state.basecode.impot_revenu.decote.seuil_celib
+        const basescouple = this.state.basecode.impot_revenu.decote.seuil_couple
+
+        return (
+            <Typography variant="body2" color="inherit">
+               ... ne peut excéder 
+               {this.baseOutputInput("plafond_qf.maries_ou_pacses")}
+               € par demi-part ou la moitié de cette somme par quart de part
+               s'ajoutant à une part pour les contribuables célibataires, divorcés, veufs ou soumis à
+               l'imposition distincte prévue au 4 de l'article 6 et à deux parts pour les contribuables
+               mariés soumis à une imposition commune.
+            
+            Toutefois, pour les contribuables célibataires, divorcés, ou soumis à l'imposition distincte
+            prévue au 4 de l'article 6 qui répondent aux conditions fixées au II de l'article 194,
+            la réduction d'impôt correspondant à la part accordée au titre du premier enfant à charge est limitée
+            à {this.baseOutputInput("plafond_qf.celib_enf")} € Lorsque les contribuables entretiennent uniquement des enfants dont la charge est réputée
+            également partagée entre l'un et l'autre des parents, la réduction d'impôt correspondant à la
+            demi-part accordée au titre de chacun des deux premiers enfants est limitée à la moitié de cette
+            somme. Par dérogation aux dispositions du premier alinéa, la réduction d'impôt résultant de
+            l'application du quotient familial, accordée aux contribuables qui bénéficient des dispositions
+            des a, b et e du 1 de l'article 195, ne peut excéder {this.baseOutputInput("plafond_qf.celib")}€ ;
+            <br/>
+            Les contribuables qui bénéficient d'une demi-part au titre des a, b, c, d, d bis, e et f du 1
+            ainsi que des 2 à 6 de l'article 195 ont droit à une réduction d'impôt égale à {this.baseOutputInput("plafond_qf.reduc_postplafond")}pour
+            chacune de ces demi-parts lorsque la réduction de leur cotisation d'impôt est plafonnée en
+            application du premier alinéa. La réduction d'impôt est égale à la moitié de cette somme lorsque
+            la majoration visée au 2 de l'article 195 est de un quart de part. Cette réduction d'impôt ne peut
+            toutefois excéder l'augmentation de la cotisation d'impôt résultant du plafonnement. Les
+            contribuables veufs ayant des enfants à charge qui bénéficient d'une part supplémentaire de
+            quotient familial en application du I de l'article 194 ont droit à une réduction d'impôt égale à
+            {this.baseOutputInput("plafond_qf.reduc_postplafond_veuf")}€ pour cette part supplémentaire lorsque la réduction de leur cotisation d'impôt est plafonnée
+            en application du premier alinéa du présent 2. Cette réduction d'impôt ne peut toutefois excéder
+            l'augmentation de la cotisation d'impôt résultant du plafonnement.
+        </Typography>
+        )
+    }
+
+    alinea4a() {
         const scelib = this.state.reforme.impot_revenu.decote.seuil_celib
         const scouple = this.state.reforme.impot_revenu.decote.seuil_couple
         const basescelib = this.state.basecode.impot_revenu.decote.seuil_celib
@@ -320,6 +374,8 @@ class Article extends React.Component {
         )
     }
 
+
+
     render() {
         const { expanded, reforme, basecode } = this.state
         const styleExpansionpanel = {
@@ -421,43 +477,7 @@ class Article extends React.Component {
                     </ExpansionPanelSummary>
 
                     <ExpansionPanelDetails style={styleExpansionpanel}>
-                        <Typography variant="body2" color="inherit">
-                            ... ne peut excéder 1 551 € par demi-part ou la moitié de cette somme
-                            par quart de part s&#39;ajoutant à une part pour les contribuables
-                            célibataires, divorcés, veufs ou soumis à l&#39;imposition distincte
-                            prévue au 4 de l&#39;article 6 et à deux parts pour les contribuables
-                            mariés soumis à une imposition commune.
-                            <br />
-                            Toutefois, pour les contribuables célibataires, divorcés, ou soumis à
-                            l&#39;imposition distincte prévue au 4 de l&#39;article 6 qui répondent
-                            aux conditions fixées au II de l&#39;article 194, la réduction
-                            d&#39;impôt correspondant à la part accordée au titre du premier enfant
-                            à charge est limitée à 3 660 € Lorsque les contribuables entretiennent
-                            uniquement des enfants dont la charge est réputée également partagée
-                            entre l&#39;un et l&#39;autre des parents, la réduction d&#39;impôt
-                            correspondant à la demi-part accordée au titre de chacun des deux
-                            premiers enfants est limitée à la moitié de cette somme. Par dérogation
-                            aux dispositions du premier alinéa, la réduction d&#39;impôt résultant
-                            de l&#39;application du quotient familial, accordée aux contribuables
-                            qui bénéficient des dispositions des a, b et e du 1 de l&#39;article
-                            195, ne peut excéder 927 € ;
-                            <br />
-                            Les contribuables qui bénéficient d'une demi-part au titre des a, b, c,
-                            d, d bis, e et f du 1 ainsi que des 2 à 6 de l'article 195 ont droit à
-                            une réduction d'impôt égale à 1 547 € pour chacune de ces demi-parts
-                            lorsque la réduction de leur cotisation d'impôt est plafonnée en
-                            application du premier alinéa. La réduction d'impôt est égale à la
-                            moitié de cette somme lorsque la majoration visée au 2 de l'article 195
-                            est de un quart de part. Cette réduction d'impôt ne peut toutefois
-                            excéder l'augmentation de la cotisation d'impôt résultant du
-                            plafonnement. Les contribuables veufs ayant des enfants à charge qui
-                            bénéficient d'une part supplémentaire de quotient familial en
-                            application du I de l'article 194 ont droit à une réduction d'impôt
-                            égale à 1 728 € pour cette part supplémentaire lorsque la réduction de
-                            leur cotisation d'impôt est plafonnée en application du premier alinéa
-                            du présent 2. Cette réduction d'impôt ne peut toutefois excéder
-                            l'augmentation de la cotisation d'impôt résultant du plafonnement.
-                        </Typography>
+                        {this.alinea2ext()}
                     </ExpansionPanelDetails>
                 </ExpansionPanel>
 
@@ -487,7 +507,7 @@ class Article extends React.Component {
                     </ExpansionPanelDetails>
                 </ExpansionPanel>
 
-                {this.alinea4()}
+                {this.alinea4a()}
             </div>
         )
     }

--- a/components/Article.jsx
+++ b/components/Article.jsx
@@ -9,7 +9,7 @@ import Fab from "@material-ui/core/Fab"
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
 import AddIcon from "@material-ui/icons/Add"
 import DeleteIcon from "@material-ui/icons/Delete"
-import { get } from "lodash/fp"
+import { get } from "lodash"
 
 // attente minimum (si l'usage n'appuye pas sur Entrée) avant qu'une saisie ne déclenche un calcul
 const WAIT_INTERVAL = 1000
@@ -253,6 +253,20 @@ class Article extends React.Component {
         )
     }
 
+    formulaOutputInputFacteur(name,fact) {
+        const regextaux = RegExp("taux")
+        const tx = regextaux.test(name)
+        const baseval = get(this.state.basecode.impot_revenu, name) * fact * (tx ? 100 : 1) // eval("this.state.basecode.impot_revenu."+name) * (tx?100:1)
+        const newval = get(this.state.reforme.impot_revenu, name) * fact * (tx ? 100 : 1) // eval("this.state.reforme.impot_revenu."+name) * (tx?100:1)
+        return (
+            <>
+                <OutputField value={baseval} style={style.VarCodeexistant} />
+                <OutputField value={newval} style={style.VarCodeNew} />
+            </>
+        )
+    }
+
+
     baseOutput(name) {
         const regextaux = RegExp("taux")
         const tx = regextaux.test(name)
@@ -438,8 +452,8 @@ pour
                 {" "}
                 €, pour la première part de quotient familial des personnes
                 célibataires, veuves ou divorcées, et à
-                {this.formulaOutputInput(
-                    "plafond_qf.reduction_ss_condition_revenus.seuil2 * 2",
+                {this.formulaOutputInputFacteur(
+                    "plafond_qf.reduction_ss_condition_revenus.seuil2",2
                 )}
                 €, pour les deux premières parts de quotient familial des
                 personnes soumises à une imposition commune. Ces seuils sont
@@ -488,8 +502,8 @@ pour
                 €, pour la première part de quotient familial des personnes
                 célibataires, veuves ou divorcées, ou
                 {" "}
-                {this.formulaOutputInput(
-                    "plafond_qf.reduction_ss_condition_revenus.seuil1 * 2",
+                {this.formulaOutputInputFacteur(
+                    "plafond_qf.reduction_ss_condition_revenus.seuil1",2
                 )}
                 €, pour les deux premières parts de quotient familial des
                 personnes soumises à une imposition commune, ces seuils étant
@@ -506,8 +520,8 @@ pour
                     "plafond_qf.reduction_ss_condition_revenus.seuil2",
                 )}
                 €, pour les personnes célibataires, veuves ou divorcées, ou
-                {this.formulaOutputInput(
-                    "plafond_qf.reduction_ss_condition_revenus.seuil2 * 2",
+                {this.formulaOutputInputFacteur(
+                    "plafond_qf.reduction_ss_condition_revenus.seuil2",2
                 )}
                 €, pour les personnes soumises à une imposition commune, ces
                 seuils étant majorés le cas échéant dans les conditions prévues

--- a/components/Article.jsx
+++ b/components/Article.jsx
@@ -313,8 +313,7 @@ class Article extends React.Component {
 
         return (
             <Typography variant="body2" color="inherit">
-                4. a. Le montant de l'impôt résultant de l'application des dispositions précédentes
-                est diminué, dans la limite de son montant, de la différence entre
+                ...la limite de son montant, de la différence entre
                 {" "}
                 <OutputField value={basescelib} style={style.VarCodeexistant} />
                 <InputField
@@ -492,8 +491,8 @@ class Article extends React.Component {
                 <ExpansionPanel
                     style={style.Typography}
                     square
-                    expanded={expanded === "panel1"}
-                    onChange={this.handleChange("panel1")}
+                    expanded={expanded === "panel0"}
+                    onChange={this.handleChange("panel0")}
                 >
                     <ExpansionPanelSummary
                         style={styleExpansionpanel}
@@ -511,6 +510,8 @@ class Article extends React.Component {
                         </Typography>
                     </ExpansionPanelDetails>
                 </ExpansionPanel>
+
+                
                 {articleTranches}
                 <div>
                     <Fab
@@ -592,7 +593,25 @@ class Article extends React.Component {
                     </ExpansionPanelDetails>
                 </ExpansionPanel>
 
-                {this.alinea4a()}
+                <ExpansionPanel
+                    style={style.Typography}
+                    square
+                    expanded={expanded === "panel4a"}
+                    onChange={this.handleChange("panel4a")}
+                >
+                    <ExpansionPanelSummary
+                        style={styleExpansionpanel}
+                        expandIcon={<ExpandMoreIcon />}
+                    >
+                        <Typography variant="body2" color="inherit">
+                        4. a. Le montant de l'impôt résultant de l'application des dispositions précédentes
+                        est diminué, dans...
+                        </Typography>
+                    </ExpansionPanelSummary>
+                    <ExpansionPanelDetails style={styleExpansionpanel}>
+                        {this.alinea4a()}
+                    </ExpansionPanelDetails>
+                </ExpansionPanel>
                 <ExpansionPanel
                     style={style.Typography}
                     square

--- a/components/Article.jsx
+++ b/components/Article.jsx
@@ -243,8 +243,10 @@ class Article extends React.Component {
     }
 
     formulaOutputInput(name){
-        const baseval=eval("this.state.basecode.impot_revenu."+name) 
-        const newval=eval("this.state.reforme.impot_revenu."+name)
+        var regextaux=RegExp("taux")
+        const tx=regextaux.test(name)
+        const baseval=eval("this.state.basecode.impot_revenu."+name)  * (tx?100:1)
+        const newval=eval("this.state.reforme.impot_revenu."+name) * (tx?100:1)
         return (<><OutputField value={baseval} style={style.VarCodeexistant} />
         <OutputField value={newval} style={style.VarCodeNew} /></>)
     }
@@ -332,7 +334,7 @@ class Article extends React.Component {
                     style={style.InputSeuil}
                 />
                 {" "}
-                € et les trois quarts de son montant pour les contribuables soumis à imposition
+                € et les <OutputField value={"trois quarts"} style={style.VarCodeexistant} /> [{this.formulaOutputInput("decote.taux")}%] de son montant pour les contribuables soumis à imposition
                 commune.
             </Typography>
         )

--- a/components/Reformeur.jsx
+++ b/components/Reformeur.jsx
@@ -293,12 +293,16 @@ class Reformeur extends Component {
     }
 
     UpdateDecote = (dectype, value) => {
+        //Pour une méthode clean mais dangereuse qui pourrait être implémentée ici, cf UpdatePlafond
         const ref = this.state.reforme
         if (dectype == "seuil_couple") {
             ref.impot_revenu.decote.seuil_couple = parseInt(value, 10)
         }
         if (dectype == "seuil_celib") {
             ref.impot_revenu.decote.seuil_celib = parseInt(value, 10)
+        }
+        if (dectype == "taux") {
+            ref.impot_revenu.decote.taux = Math.round(parseFloat(value)*10)/1000
         }
         this.setState({ reforme: ref })
     }

--- a/components/Reformeur.jsx
+++ b/components/Reformeur.jsx
@@ -13,7 +13,7 @@ import ArticleHeader from "components/ArticleHeader"
 import Divider from "@material-ui/core/Divider"
 import Impact from "components/Impact"
 import Article from "components/Article"
-import { set } from "lodash/fp"
+import { set } from "lodash"
 
 const styles = theme => ({
     paper: {

--- a/components/Reformeur.jsx
+++ b/components/Reformeur.jsx
@@ -303,12 +303,19 @@ class Reformeur extends Component {
 
     //Classy but evil ?
     UpdatePlafond = (dectype, value) => {
-        console.log("oui ca marche",dectype)
         const ref = this.state.reforme
         var regex=RegExp("^[0-9a-zA-Z_\.]+$")
+        var regextaux=RegExp("taux") // Tous les noms de variables qui contiennent taux
+        // sont divisés par 100. Je vois vraiment pas ce qui pourrait poser probleme avec ça.
         if (regex.test(dectype)){
             const pathref="ref.impot_revenu.plafond_qf"+dectype
-            eval(pathref+" = parseInt(value, 10)")
+            if (regextaux.test(dectype)){
+                const newval = value/100;
+                eval(pathref+" = parseFloat(newval, 10)")
+            }
+            else {
+                eval(pathref+" = parseInt(value, 10)")    
+            }
             console.log(ref)
             this.setState({ reforme: ref })
         }

--- a/components/Reformeur.jsx
+++ b/components/Reformeur.jsx
@@ -13,7 +13,7 @@ import ArticleHeader from "components/ArticleHeader"
 import Divider from "@material-ui/core/Divider"
 import Impact from "components/Impact"
 import Article from "components/Article"
-const _ = require('lodash');
+import { set } from "lodash/fp"
 
 const styles = theme => ({
     paper: {
@@ -52,28 +52,27 @@ class Reformeur extends Component {
                     decote: {
                         seuil_celib: 1196,
                         seuil_couple: 1970,
-                        taux: 0.75
+                        taux: 0.75,
                     },
-                    plafond_qf:{
-                        abat_dom:{
-                            taux_GuadMarReu : 0.3,
-                            plaf_GuadMarReu : 2450,
-                            taux_GuyMay : 0.4,
-                            plaf_GuyMay : 4050
+                    plafond_qf: {
+                        abat_dom: {
+                            taux_GuadMarReu: 0.3,
+                            plaf_GuadMarReu: 2450,
+                            taux_GuyMay: 0.4,
+                            plaf_GuyMay: 4050,
                         },
-                        maries_ou_pacses : 1551,
-                        celib_enf : 3660,
-                        celib : 927,
-                        reduc_postplafond : 1547,
+                        maries_ou_pacses: 1551,
+                        celib_enf: 3660,
+                        celib: 927,
+                        reduc_postplafond: 1547,
                         reduc_postplafond_veuf: 1728,
-                        reduction_ss_condition_revenus :{
-                            seuil_maj_enf: 3797, 
-                            seuil1 : 18984, 
-                            seuil2:21036, 
-                            taux:0.20
-                        }
-                    }
-
+                        reduction_ss_condition_revenus: {
+                            seuil_maj_enf: 3797,
+                            seuil1: 18984,
+                            seuil2: 21036,
+                            taux: 0.2,
+                        },
+                    },
                 },
             },
             reformebase: {
@@ -85,27 +84,27 @@ class Reformeur extends Component {
                     decote: {
                         seuil_celib: 1196,
                         seuil_couple: 1970,
-                        taux: 0.75
+                        taux: 0.75,
                     },
-                    plafond_qf:{
-                        abat_dom:{
-                            taux_GuadMarReu : 0.3,
-                            plaf_GuadMarReu : 2450,
-                            taux_GuyMay : 0.4,
-                            plaf_GuyMay : 4050
+                    plafond_qf: {
+                        abat_dom: {
+                            taux_GuadMarReu: 0.3,
+                            plaf_GuadMarReu: 2450,
+                            taux_GuyMay: 0.4,
+                            plaf_GuyMay: 4050,
                         },
-                        maries_ou_pacses : 1551,
-                        celib_enf : 3660,
-                        celib : 927,
-                        reduc_postplafond : 1547,
+                        maries_ou_pacses: 1551,
+                        celib_enf: 3660,
+                        celib: 927,
+                        reduc_postplafond: 1547,
                         reduc_postplafond_veuf: 1728,
-                        reduction_ss_condition_revenus :{
-                            seuil_maj_enf: 3797, 
-                            seuil1 : 18984, 
-                            seuil2:21036, 
-                            taux:0.20
-                        }
-                    }
+                        reduction_ss_condition_revenus: {
+                            seuil_maj_enf: 3797,
+                            seuil1: 18984,
+                            seuil2: 21036,
+                            taux: 0.2,
+                        },
+                    },
                 },
             },
             res_brut: {
@@ -269,32 +268,36 @@ class Reformeur extends Component {
 
     UpdateBareme = (i, value) => {
         const ref = this.state.reforme
-        const list = this.state.reforme.impot_revenu.bareme.seuils.map((item, j) => {
-            if (j === i) {
-                const valchiffre = parseInt(value, 10)
-                return isNaN(valchiffre) ? item : valchiffre
-            }
-            return item
-        })
+        const list = this.state.reforme.impot_revenu.bareme.seuils.map(
+            (item, j) => {
+                if (j === i) {
+                    const valchiffre = parseInt(value, 10)
+                    return isNaN(valchiffre) ? item : valchiffre
+                }
+                return item
+            },
+        )
         ref.impot_revenu.bareme.seuils = list
         this.setState({ reforme: ref })
     }
 
     UpdateTaux = (i, value) => {
         const ref = this.state.reforme
-        const list = this.state.reforme.impot_revenu.bareme.taux.map((item, j) => {
-            if (j === i) {
-                const valchiffre = parseInt(value, 10)
-                return isNaN(valchiffre) ? item : valchiffre
-            }
-            return item
-        })
+        const list = this.state.reforme.impot_revenu.bareme.taux.map(
+            (item, j) => {
+                if (j === i) {
+                    const valchiffre = parseInt(value, 10)
+                    return isNaN(valchiffre) ? item : valchiffre
+                }
+                return item
+            },
+        )
         ref.impot_revenu.bareme.taux = list
         this.setState({ reforme: ref })
     }
 
     UpdateDecote = (dectype, value) => {
-        //Pour une méthode clean mais dangereuse qui pourrait être implémentée ici, cf UpdatePlafond
+        // Pour une méthode clean mais dangereuse qui pourrait être implémentée ici, cf UpdatePlafond
         const ref = this.state.reforme
         if (dectype === "") {
             ref.impot_revenu.decote.seuil_couple = parseInt(value, 10)
@@ -303,23 +306,22 @@ class Reformeur extends Component {
             ref.impot_revenu.decote.seuil_celib = parseInt(value, 10)
         }
         if (dectype === "taux") {
-            ref.impot_revenu.decote.taux = Math.round(parseFloat(value)*10)/1000
+            ref.impot_revenu.decote.taux = Math.round(parseFloat(value) * 10) / 1000
         }
         this.setState({ reforme: ref })
     }
 
-
-    //eval("ref.impot_revenu.plafond_qf.maries_ou_pacses = 10000")
-    //lodash.set(ref,"impot_revenu.plafond_qf.maries_ou_pacses", 10000)
+    // eval("ref.impot_revenu.plafond_qf.maries_ou_pacses = 10000")
+    // lodash.set(ref,"impot_revenu.plafond_qf.maries_ou_pacses", 10000)
 
     UpdatePlafond = (dectype, value) => {
         const ref = this.state.reforme
-        var regex=RegExp("^[0-9a-zA-Z_\.]+$")
-        var regextaux=RegExp("taux") // Tous les noms de variables qui contiennent taux
+        const regex = RegExp("^[0-9a-zA-Z_.]+$")
+        const regextaux = RegExp("taux") // Tous les noms de variables qui contiennent taux
         // sont divisés par 100. Je vois vraiment pas ce qui pourrait poser probleme avec ça.
-        if (regex.test(dectype)){
-            const pathref="impot_revenu.plafond_qf"+dectype
-            _.set(ref,pathref,value * (regextaux.test(dectype)?0.01:1))
+        if (regex.test(dectype)) {
+            const pathref = `impot_revenu.plafond_qf${dectype}`
+            set(ref, pathref, value * (regextaux.test(dectype) ? 0.01 : 1))
             this.setState({ reforme: ref })
         }
     }
@@ -500,10 +502,17 @@ class Reformeur extends Component {
                                         <div>
                                             {/* <div>You are sized like a tablet or mobile phone though</div> */}
                                             <div className={classes.root}>
-                                                <AppBar position="static" color="default">
+                                                <AppBar
+                                                    position="static"
+                                                    color="default"
+                                                >
                                                     <Tabs
-                                                        value={this.state.indextab}
-                                                        onChange={this.handleTabChange}
+                                                        value={
+                                                            this.state.indextab
+                                                        }
+                                                        onChange={
+                                                            this.handleTabChange
+                                                        }
                                                         indicatorColor="primary"
                                                         textColor="primary"
                                                         variant="fullWidth"
@@ -514,37 +523,77 @@ class Reformeur extends Component {
                                                 </AppBar>
                                                 <SwipeableViews
                                                     axis={
-                                                        theme.direction === "rtl"
+                                                        theme.direction
+                                                        === "rtl"
                                                             ? "x-reverse"
                                                             : "x"
                                                     }
                                                     index={this.state.indextab}
-                                                    onChangeIndex={this.handleIndexChange}
+                                                    onChangeIndex={
+                                                        this.handleIndexChange
+                                                    }
                                                 >
-                                                    <TabContainer dir={theme.direction}>
+                                                    <TabContainer
+                                                        dir={theme.direction}
+                                                    >
                                                         <Paper>
                                                             <ArticleHeader />
                                                             <Divider />
                                                             <Article
-                                                                reforme={this.state.reforme}
-                                                                reformebase={this.state.reformebase}
-                                                                onChange={this.handleChange}
-                                                                addTranche={this.addTranche}
-                                                                removeTranche={this.removeTranche}
+                                                                reforme={
+                                                                    this.state
+                                                                        .reforme
+                                                                }
+                                                                reformebase={
+                                                                    this.state
+                                                                        .reformebase
+                                                                }
+                                                                onChange={
+                                                                    this
+                                                                        .handleChange
+                                                                }
+                                                                addTranche={
+                                                                    this
+                                                                        .addTranche
+                                                                }
+                                                                removeTranche={
+                                                                    this
+                                                                        .removeTranche
+                                                                }
                                                             />
                                                         </Paper>
                                                     </TabContainer>
-                                                    <TabContainer dir={theme.direction}>
+                                                    <TabContainer
+                                                        dir={theme.direction}
+                                                    >
                                                         <Impact
-                                                            loading={this.state.loading}
-                                                            onRevenuChange={this.handleRevenuChange}
-                                                            onOutreMerChange={
-                                                                this.handleOutreMerChange
+                                                            loading={
+                                                                this.state
+                                                                    .loading
                                                             }
-                                                            res_brut={this.state.res_brut}
-                                                            total_pop={this.state.total_pop}
-                                                            onClick={this.simPop}
-                                                            cas_types={this.state.cas_types}
+                                                            onRevenuChange={
+                                                                this
+                                                                    .handleRevenuChange
+                                                            }
+                                                            onOutreMerChange={
+                                                                this
+                                                                    .handleOutreMerChange
+                                                            }
+                                                            res_brut={
+                                                                this.state
+                                                                    .res_brut
+                                                            }
+                                                            total_pop={
+                                                                this.state
+                                                                    .total_pop
+                                                            }
+                                                            onClick={
+                                                                this.simPop
+                                                            }
+                                                            cas_types={
+                                                                this.state
+                                                                    .cas_types
+                                                            }
                                                         />
                                                     </TabContainer>
                                                 </SwipeableViews>
@@ -556,23 +605,35 @@ class Reformeur extends Component {
                                     <div>
                                         {/* <div>You also have a good screen</div> */}
                                         <div className="moitie-gauche">
-                                            <Paper className={this.props.classes.paper}>
+                                            <Paper
+                                                className={
+                                                    this.props.classes.paper
+                                                }
+                                            >
                                                 <ArticleHeader />
                                                 <Divider />
                                                 <Article
                                                     reforme={this.state.reforme}
-                                                    reformebase={this.state.reformebase}
+                                                    reformebase={
+                                                        this.state.reformebase
+                                                    }
                                                     onChange={this.handleChange}
                                                     addTranche={this.addTranche}
-                                                    removeTranche={this.removeTranche}
+                                                    removeTranche={
+                                                        this.removeTranche
+                                                    }
                                                 />
                                             </Paper>
                                         </div>
                                         <div className="moitie-droite">
                                             <Impact
                                                 loading={this.state.loading}
-                                                onRevenuChange={this.handleRevenuChange}
-                                                onOutreMerChange={this.handleOutreMerChange}
+                                                onRevenuChange={
+                                                    this.handleRevenuChange
+                                                }
+                                                onOutreMerChange={
+                                                    this.handleOutreMerChange
+                                                }
                                                 res_brut={this.state.res_brut}
                                                 total_pop={this.state.total_pop}
                                                 onClick={this.simPop}
@@ -604,7 +665,11 @@ class Reformeur extends Component {
                                     </Tabs>
                                 </AppBar>
                                 <SwipeableViews
-                                    axis={theme.direction === "rtl" ? "x-reverse" : "x"}
+                                    axis={
+                                        theme.direction === "rtl"
+                                            ? "x-reverse"
+                                            : "x"
+                                    }
                                     index={this.state.indextab}
                                     onChangeIndex={this.handleIndexChange}
                                 >
@@ -620,8 +685,12 @@ class Reformeur extends Component {
                                     <TabContainer dir={theme.direction}>
                                         <Impact
                                             loading={this.state.loading}
-                                            onRevenuChange={this.handleRevenuChange}
-                                            onOutreMerChange={this.handleOutreMerChange}
+                                            onRevenuChange={
+                                                this.handleRevenuChange
+                                            }
+                                            onOutreMerChange={
+                                                this.handleOutreMerChange
+                                            }
                                             res_brut={this.state.res_brut}
                                             total_pop={this.state.total_pop}
                                             onClick={this.simPop}

--- a/components/Reformeur.jsx
+++ b/components/Reformeur.jsx
@@ -13,6 +13,7 @@ import ArticleHeader from "components/ArticleHeader"
 import Divider from "@material-ui/core/Divider"
 import Impact from "components/Impact"
 import Article from "components/Article"
+const _ = require('lodash');
 
 const styles = theme => ({
     paper: {
@@ -295,34 +296,30 @@ class Reformeur extends Component {
     UpdateDecote = (dectype, value) => {
         //Pour une méthode clean mais dangereuse qui pourrait être implémentée ici, cf UpdatePlafond
         const ref = this.state.reforme
-        if (dectype == "seuil_couple") {
+        if (dectype === "") {
             ref.impot_revenu.decote.seuil_couple = parseInt(value, 10)
         }
-        if (dectype == "seuil_celib") {
+        if (dectype === "seuil_celib") {
             ref.impot_revenu.decote.seuil_celib = parseInt(value, 10)
         }
-        if (dectype == "taux") {
+        if (dectype === "taux") {
             ref.impot_revenu.decote.taux = Math.round(parseFloat(value)*10)/1000
         }
         this.setState({ reforme: ref })
     }
 
-    //Classy but evil ?
+
+    //eval("ref.impot_revenu.plafond_qf.maries_ou_pacses = 10000")
+    //lodash.set(ref,"impot_revenu.plafond_qf.maries_ou_pacses", 10000)
+
     UpdatePlafond = (dectype, value) => {
         const ref = this.state.reforme
         var regex=RegExp("^[0-9a-zA-Z_\.]+$")
         var regextaux=RegExp("taux") // Tous les noms de variables qui contiennent taux
         // sont divisés par 100. Je vois vraiment pas ce qui pourrait poser probleme avec ça.
         if (regex.test(dectype)){
-            const pathref="ref.impot_revenu.plafond_qf"+dectype
-            if (regextaux.test(dectype)){
-                const newval = value/100;
-                eval(pathref+" = parseFloat(newval, 10)")
-            }
-            else {
-                eval(pathref+" = parseInt(value, 10)")    
-            }
-            console.log(ref)
+            const pathref="impot_revenu.plafond_qf"+dectype
+            _.set(ref,pathref,value * (regextaux.test(dectype)?0.01:1))
             this.setState({ reforme: ref })
         }
     }
@@ -394,23 +391,23 @@ class Reformeur extends Component {
 
     handleChange(value, name) {
         const success = false
-        const newvalue = value == "" ? 0 : value
-        if (name.substring(0, 5) == "seuil") {
+        const newvalue = value === "" ? 0 : value
+        if (name.substring(0, 5) === "seuil") {
             const numb = parseInt(name.substring(5), 10)
             this.UpdateBareme(numb, newvalue)
             // success=true;
         }
-        if (name.substring(0, 4) == "taux") {
+        if (name.substring(0, 4) === "taux") {
             const numb = parseInt(name.substring(4), 10)
             this.UpdateTaux(numb, newvalue)
             // success=true;
         }
-        if (name.substring(0, 6) == "decote") {
+        if (name.substring(0, 6) === "decote") {
             const whichdecote = name.substring(7)
             this.UpdateDecote(whichdecote, newvalue)
             // success=true;
         }
-        if (name.substring(0, 10) == "plafond_qf") {
+        if (name.substring(0, 10) === "plafond_qf") {
             const whichplaf = name.substring(10)
             this.UpdatePlafond(whichplaf, newvalue)
             // success=true;

--- a/components/Reformeur.jsx
+++ b/components/Reformeur.jsx
@@ -51,6 +51,7 @@ class Reformeur extends Component {
                     decote: {
                         seuil_celib: 1196,
                         seuil_couple: 1970,
+                        taux: 0.75
                     },
                     plafond_qf:{
                         abat_dom:{
@@ -83,6 +84,7 @@ class Reformeur extends Component {
                     decote: {
                         seuil_celib: 1196,
                         seuil_couple: 1970,
+                        taux: 0.75
                     },
                     plafond_qf:{
                         abat_dom:{

--- a/components/Reformeur.jsx
+++ b/components/Reformeur.jsx
@@ -52,6 +52,26 @@ class Reformeur extends Component {
                         seuil_celib: 1196,
                         seuil_couple: 1970,
                     },
+                    plafond_qf:{
+                        abat_dom:{
+                            taux_GuadMarReu : 0.3,
+                            plaf_GuadMarReu : 2450,
+                            taux_GuyMay : 0.4,
+                            plaf_GuyMay : 4050
+                        },
+                        maries_ou_pacses : 1551,
+                        celib_enf : 3660,
+                        celib : 927,
+                        reduc_postplafond : 1547,
+                        reduc_postplafond_veuf: 1728,
+                        reduction_ss_condition_revenus :{
+                            seuil_maj_enf: 3797, 
+                            seuil1 : 18984, 
+                            seuil2:21036, 
+                            taux:0.20
+                        }
+                    }
+
                 },
             },
             reformebase: {
@@ -64,6 +84,25 @@ class Reformeur extends Component {
                         seuil_celib: 1196,
                         seuil_couple: 1970,
                     },
+                    plafond_qf:{
+                        abat_dom:{
+                            taux_GuadMarReu : 0.3,
+                            plaf_GuadMarReu : 2450,
+                            taux_GuyMay : 0.4,
+                            plaf_GuyMay : 4050
+                        },
+                        maries_ou_pacses : 1551,
+                        celib_enf : 3660,
+                        celib : 927,
+                        reduc_postplafond : 1547,
+                        reduc_postplafond_veuf: 1728,
+                        reduction_ss_condition_revenus :{
+                            seuil_maj_enf: 3797, 
+                            seuil1 : 18984, 
+                            seuil2:21036, 
+                            taux:0.20
+                        }
+                    }
                 },
             },
             res_brut: {
@@ -262,6 +301,19 @@ class Reformeur extends Component {
         this.setState({ reforme: ref })
     }
 
+    //Classy but evil ?
+    UpdatePlafond = (dectype, value) => {
+        console.log("oui ca marche",dectype)
+        const ref = this.state.reforme
+        var regex=RegExp("^[0-9a-zA-Z_\.]+$")
+        if (regex.test(dectype)){
+            const pathref="ref.impot_revenu.plafond_qf"+dectype
+            eval(pathref+" = parseInt(value, 10)")
+            console.log(ref)
+            this.setState({ reforme: ref })
+        }
+    }
+
     addTranche(e) {
         const refbase = this.state.reforme
         const newnbt = refbase.impot_revenu.bareme.seuils.length + 1
@@ -343,6 +395,11 @@ class Reformeur extends Component {
         if (name.substring(0, 6) == "decote") {
             const whichdecote = name.substring(7)
             this.UpdateDecote(whichdecote, newvalue)
+            // success=true;
+        }
+        if (name.substring(0, 10) == "plafond_qf") {
+            const whichplaf = name.substring(10)
+            this.UpdatePlafond(whichplaf, newvalue)
             // success=true;
         }
         const bodyreq = this.cas_types_defaut


### PR DESCRIPTION
- retrait du tag retraité (oui ca n'a rien à foutre ici, mais j'ai par erreur commencé sur une autre branche)
- Ajout de nombreux paramètres modifiables : 
    - réfaction
    - plafonnement QF
    - abattement dom
- Extension Panels sont désormais indépendants

cf trello cards : 
https://trello.com/c/bRM1ebPq/129-ajouter-les-reductions-outre-mer
https://trello.com/c/27Hd0DEZ/128-refaction
https://trello.com/c/SJIPARgM/127-ajouter-les-plafonds-du-quotient-familial
https://trello.com/c/lgPYXeL9/79-article-expansionpanel-1-seul-%C3%A0-la-fois


Attention :   
- ne pas merger cette PR avant que [celle-ci ](https://github.com/betagouv/leximpact-server/pull/33) ne soit acceptée sur le server
- Vérifier que cette version utilise bien la dernière version d'Openfisca France
- Regarder attentivement notamment les différents points suivants:
    - Chaque morceau de l'article 197 est désormais dans un Expansion Panel différent
    - Chaque Expansion Panel n'est signalé que par les premiers mots de l'alinéa. On pourrait rajouter (en Tooltip ou à la place des premiers mots) une caractérisation de l'alinéa (genre "Alinéa 2 : plafonnement du QF"), à voir de quelle manière
     - Certains nombres dans la loi sont des formules par rapport à d'autres sans que ce soit explicité dans le texte de loi. Genre dans l'image ci dessus : (Texte surligné 2) = 2 x (Texte surligné 1)  et  (Texte surligné 2) = 2 x (Texte surligné 1)  et  (Texte surligné 4) = (Texte surligné 1)  - (Texte surligné 3) 
![image](https://user-images.githubusercontent.com/17675313/60724206-115f0100-9f36-11e9-9473-0db2310a08ff.png)  . Vérifier comment on veut les faire apparaître.  Pour l'instant, c'est également incohérent avec la manière dont on fait apparaître les modifications dans le barême.
