### PR TITLE
[WIP]Taux barême en pourcentage

### DIFF
--- a/components/Article.jsx
+++ b/components/Article.jsx
@@ -194,7 +194,7 @@ class Article extends React.Component {
         const ref = this.state.reforme
         const list = this.state.reforme.impot_revenu.bareme.taux.map((item, j) => {
             if (j === i) {
-                return value
+                return value*0.01
             }
             return item
         })


### PR DESCRIPTION
Les call API envoient désormais les taux en valeur et non en pourcentage ( l'API call contient 0.25 au lieu de 25  pour les taux du barême de l'IR)

Pour merger cette PR, il faut :
- merger la correspondante dans le server en même temps (elle s'appelle aussi pourcentage_bareme_taux)
- la rebaser sur le master parce que là je l'ai foutue un peu n'importe où 