### PR TITLE
🔠 ajout des graisses light,regular,bold pour la font lato

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -69,7 +69,7 @@ class MyDocument extends Document {
                     />
                     <link
                         rel="stylesheet"
-                        href="https://fonts.googleapis.com/css?family=Lato|Lora"
+                        href="https://fonts.googleapis.com/css?family=Lato:300,400,700|Lora"
                     />
                 </Head>
                 <body>


### PR DESCRIPTION
la font Lora n'a pas de graisse light
https://fonts.google.com/specimen/Lora