### PR TITLE
Modifs demandée démo 16/09

### DIFF
--- a/components/articles/article-alinea-4a/article-alinea-4a-component.jsx
+++ b/components/articles/article-alinea-4a/article-alinea-4a-component.jsx
@@ -51,7 +51,7 @@ class Alinea4a extends PureComponent {
     return (
       <LexExpansionPanel
         square
-        expanded={isPanelExpanded}
+        expanded={true}
         style={style.Typography}
         onChange={expandArticlePanelHandler}>
         <LexExpansionPanelSummary

--- a/components/articles/article-alinea-4b/article-alinea-4b-component.jsx
+++ b/components/articles/article-alinea-4b/article-alinea-4b-component.jsx
@@ -175,7 +175,7 @@ class Alinea4b extends PureComponent {
     return (
       <LexExpansionPanel
         square
-        expanded={isPanelExpanded}
+        expanded={true}
         style={style.Typography}
         onChange={expandArticlePanelHandler}>
         <LexExpansionPanelSummary

--- a/components/carte-etat/carte-etat-component.jsx
+++ b/components/carte-etat/carte-etat-component.jsx
@@ -42,10 +42,11 @@ const styles = () => ({
   sourceInsee: {
     color: "#B1B1B1",
     fontFamily: "Lato",
-    fontSize: "11px",
+    fontSize: "12px",
     fontWeight: "regular",
     marginLeft: "14px",
     marginBottom: "30px",
+    textAlign: "right",
   },
   subtitleCarteEtat: {
     color: "#565656",
@@ -134,7 +135,8 @@ class CarteEtat extends PureComponent {
             </div>
           )}
           <div>
-            <Typography className={classes.sourceInsee}>*Réalisation à partir des données de l’Enquête Revenus Fiscaux et Sociaux, de l'INSEE.
+            <Typography className={classes.sourceInsee}>* Chiffrages indicatifs.
+            <br /> Réalisation à partir des données de l’Enquête Revenus Fiscaux et Sociaux de l'INSEE (2014).
             </Typography>
           </div>
           <div>


### PR DESCRIPTION
J'ai pu réaliser quelques modifs demandées aujourd'hui : 

- la légende carte recettes État est mise à jour avec "Chiffrage indicatif"

- les panneaux dans l'article sont étendus là où le PLF a effectué une modification pour être plus visibles, c'est pas fou mais c'est un peu mieux

- J'ai essayé, mais je n'ai pas réussi à ajouter les paramètres "salaire médian", "salaire moyen" "smic" dans la liste des salaires à sélectionner. 

Ce serait bien de valider la PR pour au moins les deux premiers points pour demain, afin d'être un peu plus à jour pour les démos ! 