### PR TITLE
Carte Recettes État- Ajout tableau infos déciles

### DIFF
--- a/components/carte-etat/bar-chart.scss
+++ b/components/carte-etat/bar-chart.scss
@@ -82,4 +82,5 @@
 
 .styleExpansionPanel {
   margin: 0px;
+  overflow-x:scroll;
 }

--- a/components/carte-etat/bar-chart.scss
+++ b/components/carte-etat/bar-chart.scss
@@ -79,3 +79,7 @@
 .nobreak {
   overflow: hidden;
 }
+
+.styleExpansionPanel {
+  margin: 0px;
+}

--- a/components/carte-etat/carte-etat-component.jsx
+++ b/components/carte-etat/carte-etat-component.jsx
@@ -28,7 +28,6 @@ const styles = () => ({
     marginTop: "83px",
     marginBottom: "90px",
   },
-  card: {},
   div: {
     padding: 7,
   },
@@ -112,7 +111,7 @@ class CarteEtat extends PureComponent {
     const totalApres = getRoundedTotal(apres);
     const totalPLF = getRoundedTotal(plf);
     return (
-      <Card className={classes.card}>
+      <Card>
         <CardContent>
           <div className="title-wrapper">
             <div className="divTitre">

--- a/components/carte-etat/carte-etat-component.jsx
+++ b/components/carte-etat/carte-etat-component.jsx
@@ -1,5 +1,4 @@
 import classicalBuilding from "@iconify/icons-twemoji/classical-building";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import { Icon } from "@iconify/react";
 import {
   Button,
@@ -11,17 +10,18 @@ import {
 import ExpansionPanel from "@material-ui/core/ExpansionPanel";
 import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
 import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
-import SimpopTableurInfosDeciles from "./simpop-tableur-infos-deciles";
 import { withStyles } from "@material-ui/core/styles";
 import {
   AccountBalance as AccountBalanceIcon,
   Cached as CachedIcon,
   Face as FaceIcon,
 } from "@material-ui/icons";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import PropTypes from "prop-types";
 import { PureComponent } from "react";
 
 import BarChart from "./bar-chart";
+import SimpopTableurInfosDeciles from "./simpop-tableur-infos-deciles";
 
 const styles = () => ({
   buttonPosition: {
@@ -68,7 +68,7 @@ const styles = () => ({
     fontSize: "12px",
     fontWeight: "regular",
     marginLeft: "14px",
-    marginBottom: "30px", //
+    marginBottom: "0px", //
     textAlign: "right",
   },
   subtitleCarteEtat: {
@@ -84,14 +84,12 @@ const styles = () => ({
     fontWeight: "bold",
     padding: "0 0 0 10px",
   },
-
 });
 
 function getRoundedTotal(value) {
   const rounded = Math.round(value / 100000000) / 10;
   return rounded;
 }
-
 
 class CarteEtat extends PureComponent {
   render() {
@@ -183,7 +181,8 @@ class CarteEtat extends PureComponent {
                   <Typography className={classes.sourceInsee}>
                     * Chiffrages indicatifs.
                     <br />
-                    {" "}Estimation à partir des données de l&apos;Enquête
+                    {" "}
+Estimation à partir des données de l&apos;Enquête
                     Revenus Fiscaux et Sociaux de l&apos;INSEE.
                   </Typography>
                 </div>
@@ -191,10 +190,14 @@ class CarteEtat extends PureComponent {
             ]
           )}
         </CardContent>
-        <ExpansionPanel expanded={isPanelExpanded} onChange={expandArticlePanelHandler}>
-          <ExpansionPanelSummary className="styleExpansionPanel" expandIcon={<ExpandMoreIcon />}>
+        <ExpansionPanel
+          expanded={isPanelExpanded}
+          onChange={expandArticlePanelHandler}>
+          <ExpansionPanelSummary
+            className="styleExpansionPanel"
+            expandIcon={<ExpandMoreIcon />}>
             <Typography className={classes.subtitleCarteEtat}>
-            En savoir plus sur les déciles de population
+              En savoir plus sur les déciles de population
             </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails className="styleExpansionPanel">

--- a/components/carte-etat/carte-etat-component.jsx
+++ b/components/carte-etat/carte-etat-component.jsx
@@ -221,7 +221,7 @@ class CarteEtat extends PureComponent {
             </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
-            <SimpopTableurInfosDeciles />
+            <SimpopTableurInfosDeciles deciles ={deciles} />
           </ExpansionPanelDetails>
         </ExpansionPanel>
       </Card>

--- a/components/carte-etat/carte-etat-component.jsx
+++ b/components/carte-etat/carte-etat-component.jsx
@@ -71,7 +71,6 @@ const styles = () => ({
     marginBottom: "30px", //
     textAlign: "right",
   },
-
   subtitleCarteEtat: {
     color: "#565656",
     fontFamily: "Lato",
@@ -199,7 +198,7 @@ class CarteEtat extends PureComponent {
             </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails className="styleExpansionPanel">
-            <SimpopTableurInfosDeciles deciles ={deciles} />
+            <SimpopTableurInfosDeciles deciles={deciles} />
           </ExpansionPanelDetails>
         </ExpansionPanel>
       </Card>

--- a/components/carte-etat/carte-etat-component.jsx
+++ b/components/carte-etat/carte-etat-component.jsx
@@ -192,26 +192,6 @@ class CarteEtat extends PureComponent {
               ),
             ]
           )}
-          <div>
-            <Typography className={classes.sourceInsee}>
-            *Réalisation à partir des données de l&apos;Enquête
-            Revenus Fiscaux et Sociaux, de l&apos;INSEE.
-            </Typography>
-          </div>
-          <div>
-            <center>
-              <Button
-                color="secondary"
-                size="medium"
-                variant="outlined"
-                onClick={onClickSimPop}>
-                <AccountBalanceIcon />
-                <FaceIcon className={classes.marginIcon} />
-                &nbsp;Estimer ~60&quot;
-                <CachedIcon className={classes.miniIcon} />
-              </Button>
-            </center>
-          </div>
         </CardContent>
         <ExpansionPanel expanded={isPanelExpanded} onChange={expandArticlePanelHandler}>
           <ExpansionPanelSummary className="styleExpansionPanel" expandIcon={<ExpandMoreIcon />}>

--- a/components/carte-etat/carte-etat-component.jsx
+++ b/components/carte-etat/carte-etat-component.jsx
@@ -1,4 +1,5 @@
 import classicalBuilding from "@iconify/icons-twemoji/classical-building";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import { Icon } from "@iconify/react";
 import {
   Button,
@@ -7,6 +8,10 @@ import {
   CircularProgress,
   Typography,
 } from "@material-ui/core";
+import ExpansionPanel from "@material-ui/core/ExpansionPanel";
+import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
+import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
+import SimpopTableurInfosDeciles from "./simpop-tableur-infos-deciles";
 import { withStyles } from "@material-ui/core/styles";
 import {
   AccountBalance as AccountBalanceIcon,
@@ -34,6 +39,9 @@ const styles = () => ({
   iconEtat: {
     fontSize: "50px",
   },
+  mainChart: {
+    flex: "1",
+  },
   marginIcon: {
     marginRight: "20px",
   },
@@ -46,14 +54,25 @@ const styles = () => ({
   pom_verte: {
     color: "#00FF00",
   },
+  simpop: {
+    display: "flex",
+    flex: "1",
+    flexDirection: "column",
+    height: "25vh",
+    marginTop: "10px",
+    paddingLeft: "3px",
+    width: "50%",
+  },
   sourceInsee: {
     color: "#B1B1B1",
     fontFamily: "Lato",
     fontSize: "12px",
     fontWeight: "regular",
     marginLeft: "14px",
+    marginBottom: "30px", //
     textAlign: "right",
   },
+
   subtitleCarteEtat: {
     color: "#565656",
     fontFamily: "Lato",
@@ -67,19 +86,7 @@ const styles = () => ({
     fontWeight: "bold",
     padding: "0 0 0 10px",
   },
-  simpop: {
-    height: "25vh",
-    width: "50%",
-    display: "flex",
-    flexDirection: "column",
-    paddingLeft: "3px",
-    width: "50px",
-    flex: "1",
-    marginTop: "10px",
-  },
-  mainChart: {
-    flex: "1",
-  },
+
 });
 
 function getRoundedTotal(value) {
@@ -87,13 +94,16 @@ function getRoundedTotal(value) {
   return rounded;
 }
 
+
 class CarteEtat extends PureComponent {
   render() {
     const {
       classes,
       deciles,
+      expandArticlePanelHandler,
       isDisabledEtat,
       isLoadingEtat,
+      isPanelExpanded,
       onClickSimPop,
       total,
     } = this.props;
@@ -128,7 +138,7 @@ class CarteEtat extends PureComponent {
                   onClick={onClickSimPop}>
                   <AccountBalanceIcon />
                   <FaceIcon className={classes.marginIcon} />
-                  &nbsp;Estimer ~60"
+                  &nbsp;Estimer ~60&quot;
                   <CachedIcon className={classes.miniIcon} />
                 </Button>
               </center>
@@ -176,14 +186,44 @@ class CarteEtat extends PureComponent {
                     * Chiffrages indicatifs.
                     <br />
                     {" "}
-Estimation à partir des données de l&apos;Enquête
+                    Estimation à partir des données de l&apos;Enquête
                     Revenus Fiscaux et Sociaux de l&apos;INSEE.
                   </Typography>
                 </div>
               ),
             ]
           )}
+          <div>
+            <Typography className={classes.sourceInsee}>
+            *Réalisation à partir des données de l&apos;Enquête
+            Revenus Fiscaux et Sociaux, de l&apos;INSEE.
+            </Typography>
+          </div>
+          <div>
+            <center>
+              <Button
+                color="secondary"
+                size="medium"
+                variant="outlined"
+                onClick={onClickSimPop}>
+                <AccountBalanceIcon />
+                <FaceIcon className={classes.marginIcon} />
+                &nbsp;Estimer ~60''
+                <CachedIcon className={classes.miniIcon} />
+              </Button>
+            </center>
+          </div>
         </CardContent>
+        <ExpansionPanel expanded={isPanelExpanded} onChange={expandArticlePanelHandler}>
+          <ExpansionPanelSummary className="styleExpansionPanel" expandIcon={<ExpandMoreIcon />}>
+            <Typography className={classes.subtitleCarteEtat}>
+            En savoir plus sur les déciles de population
+            </Typography>
+          </ExpansionPanelSummary>
+          <ExpansionPanelDetails>
+            <SimpopTableurInfosDeciles />
+          </ExpansionPanelDetails>
+        </ExpansionPanel>
       </Card>
     );
   }
@@ -202,6 +242,8 @@ CarteEtat.propTypes = {
   isDisabledEtat: PropTypes.bool.isRequired,
   isLoadingEtat: PropTypes.bool.isRequired,
   onClickSimPop: PropTypes.func.isRequired,
+  isPanelExpanded: PropTypes.shape().isRequired,
+  expandArticlePanelHandler: PropTypes.shape().isRequired,
   total: PropTypes.shape({
     apres: PropTypes.number.isRequired,
     avant: PropTypes.number.isRequired,

--- a/components/carte-etat/carte-etat-component.jsx
+++ b/components/carte-etat/carte-etat-component.jsx
@@ -185,8 +185,7 @@ class CarteEtat extends PureComponent {
                   <Typography className={classes.sourceInsee}>
                     * Chiffrages indicatifs.
                     <br />
-                    {" "}
-                    Estimation à partir des données de l&apos;Enquête
+                    {" "}Estimation à partir des données de l&apos;Enquête
                     Revenus Fiscaux et Sociaux de l&apos;INSEE.
                   </Typography>
                 </div>
@@ -208,7 +207,7 @@ class CarteEtat extends PureComponent {
                 onClick={onClickSimPop}>
                 <AccountBalanceIcon />
                 <FaceIcon className={classes.marginIcon} />
-                &nbsp;Estimer ~60''
+                &nbsp;Estimer ~60&quot;
                 <CachedIcon className={classes.miniIcon} />
               </Button>
             </center>
@@ -220,7 +219,7 @@ class CarteEtat extends PureComponent {
             En savoir plus sur les déciles de population
             </Typography>
           </ExpansionPanelSummary>
-          <ExpansionPanelDetails>
+          <ExpansionPanelDetails className="styleExpansionPanel">
             <SimpopTableurInfosDeciles deciles ={deciles} />
           </ExpansionPanelDetails>
         </ExpansionPanel>

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -128,7 +128,6 @@ function imageDecile(id) {
 }
 
 function SimpopTableurInfosDeciles({ classes, deciles }) {
-  console.log(deciles)
   const rows = deciles.map((currElement, index) => create_from_deciles(index, currElement));
   return (
     <Table>

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -78,7 +78,7 @@ function createData(
 const frontdec = [3569,9053,12811,16167,19300,23895,29520,37720,52716, "∞"]
 function create_from_deciles(index, decile){
     return createData("Décile n°" + (index + 1),
-      frontdec[index] + "€/mois",
+      frontdec[index] + "€/an",
       decile["avant"] ? Math.round((decile["plf"]/decile["avant"] -1)*100) : "N/A",
       decile["avant"] ? Math.round((decile["apres"]/decile["avant"] -1)*100) : "N/A",
       Math.round(decile["avant"]/decile["poids"]),
@@ -89,7 +89,6 @@ function create_from_deciles(index, decile){
 
 
 function SimpopTableurInfosDeciles({ classes, deciles }) {
-  console.log("maprop", deciles);
   const rows = deciles.map((currElement, index) => {
     return create_from_deciles(index, currElement);
   });
@@ -99,7 +98,7 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
         <TableRow className={classes.tableStyle}>
           <TableCell padding="dense">Décile</TableCell>
           <TableCell align="center" padding="dense">
-            Salaire net /mois (jusqu&apos;à)
+            RFR (jusqu&apos;à)
           </TableCell>
           <TableCell align="center" padding="dense">
             Impact moyen sur le foyer (par rapport au code existant)

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -8,6 +8,13 @@ import TableRow from "@material-ui/core/TableRow";
 import PropTypes from "prop-types";
 
 const styles = {
+  titleCarteEtat: {
+    color: "#565656",
+    fontFamily: "Lato",
+    fontSize: "1.125em",
+    fontWeight: "bold",
+    padding: "0 0 0 10px",
+  },
   cellStyle: {
     padding: "0px",
   },
@@ -23,7 +30,6 @@ const styles = {
     marginRight: "4px",
     padding: "3px",
   },
-
   plf: {
     color: "#FF6B6B",
     fontFamily: "Lato",
@@ -55,27 +61,17 @@ let id = 0;
 function createData(
   decile,
   revenuFiscalDeReference,
-  impactMoyenFoyer_plf,
-  impactMoyenFoyer_reforme,
-  impotMoyenFoyer,
-  impotMoyenFoyer_plf,
-  impotMoyenFoyer_reforme,
-  recettesEtat,
-  recettesEtat_plf,
-  recettesEtat_reforme
+  impactMoyenFoyer_plf, impactMoyenFoyer_reforme,
+  impotMoyenFoyer, impotMoyenFoyer_plf, impotMoyenFoyer_reforme,
+  recettesEtat, recettesEtat_plf, recettesEtat_reforme
 ) {
   id += 1;
   return {
     decile,
     id,
-    impactMoyenFoyer_plf,
-    impactMoyenFoyer_reforme,
-    impotMoyenFoyer,
-    impotMoyenFoyer_plf,
-    impotMoyenFoyer_reforme,
-    recettesEtat,
-    recettesEtat_plf,
-    recettesEtat_reforme,
+    impactMoyenFoyer_plf, impactMoyenFoyer_reforme,
+    impotMoyenFoyer, impotMoyenFoyer_plf, impotMoyenFoyer_reforme,
+    recettesEtat, recettesEtat_plf, recettesEtat_reforme,
     revenuFiscalDeReference,
   };
 }
@@ -84,15 +80,9 @@ function createData(
 function create_from_deciles(index, decile) {
   // source (2016) http://www.senat.fr/rap/l16-140-211/l16-140-2111.pdf
   const revenusFiscauxDeReference = [
-    3569,
-    9053,
-    12811,
-    16167,
-    19300,
-    23895,
-    29520,
-    37720,
-    52716,
+    3569, 9053, 12811,
+    16167, 19300, 23895,
+    29520, 37720, 52716,
     "∞",
   ];
 
@@ -108,14 +98,9 @@ function create_from_deciles(index, decile) {
   return createData(
     index + 1,
     revenusFiscauxDeReference[index],
-    impactMoyenFoyer_plf,
-    impactMoyenFoyer_reforme,
-    impotMoyenFoyer,
-    impotMoyenFoyer_plf,
-    impotMoyenFoyer_reforme,
-    recettesEtat,
-    recettesEtat_plf,
-    recettesEtat_reforme
+    impactMoyenFoyer_plf, impactMoyenFoyer_reforme,
+    impotMoyenFoyer, impotMoyenFoyer_plf, impotMoyenFoyer_reforme,
+    recettesEtat, recettesEtat_plf, recettesEtat_reforme
   ); // Les recettes de l'Etat doivent être après réforme?
 }
 
@@ -129,9 +114,10 @@ function imageDecile(id) {
 
 function SimpopTableurInfosDeciles({ classes, deciles }) {
   const rows = deciles.map((currElement, index) => create_from_deciles(index, currElement));
+  const NON_APPLICABLE = "—";
   return (
     <Table>
-      <TableHead>
+      <TableHead className={classes.titleCarteEtat}>
         <TableRow className={classes.tableStyle}>
           <TableCell align="center" padding="none">
             <p>
@@ -146,7 +132,7 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
           </TableCell>
           <TableCell align="center" padding="none">
             <p>
-              <b>Impact moyen sur le foyer </b>
+              <b>Impact moyen sur le foyer</b>
             </p>
             <p>(par rapport au code existant)</p>
           </TableCell>
@@ -174,11 +160,11 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
             </TableCell>
             <TableCell align="center" padding="dense">
               <span style={styles.plf}>
-                {(row.impactMoyenFoyer_plf == "-") ? "—" : row.impactMoyenFoyer_plf+"%"}
+                {(row.impactMoyenFoyer_plf == "-") ? NON_APPLICABLE : row.impactMoyenFoyer_plf+"%"}
               </span>
               &nbsp;
               <span style={styles.reforme}>
-                {(row.impactMoyenFoyer_reforme == "-") ? "—" : row.impactMoyenFoyer_reforme+"%"}
+                {(row.impactMoyenFoyer_reforme == "-") ? NON_APPLICABLE : row.impactMoyenFoyer_reforme+"%"}
               </span>
             </TableCell>
             <TableCell align="center" padding="dense">

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -174,11 +174,11 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
             </TableCell>
             <TableCell align="center" padding="dense">
               <span style={styles.plf}>
-                {row.impactMoyenFoyer_plf}%
+                {(row.impactMoyenFoyer_plf == "-") ? "—" : row.impactMoyenFoyer_plf+"%"}
               </span>
               &nbsp;
               <span style={styles.reforme}>
-                {row.impactMoyenFoyer_reforme}%
+                {(row.impactMoyenFoyer_reforme == "-") ? "—" : row.impactMoyenFoyer_reforme+"%"}
               </span>
             </TableCell>
             <TableCell align="center" padding="dense">

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -19,8 +19,11 @@ let id = 0;
 function createData(
   decile,
   salaire,
+  impactmoyenfoyer_plf,
+  impactmoyenfoyer_reforme,
   impotmoyenfoyer,
-  impactmoyenfoyer,
+  impotmoyenfoyer_plf,
+  impotmoyenfoyer_reforme,
   recettesetat,
 ) {
   id += 1;
@@ -28,30 +31,34 @@ function createData(
     id,
     decile,
     salaire,
+    impactmoyenfoyer_plf,
+    impactmoyenfoyer_reforme,
     impotmoyenfoyer,
-    impactmoyenfoyer,
+    impotmoyenfoyer_plf,
+    impotmoyenfoyer_reforme,
     recettesetat,
   };
 }
 
+// #décile, salaire net/mois, impact foyer (plf, réforme), impôt moyen foyer (existant, plf, réforme), total recettes état
 const rows = [
-  createData("Décile n°1", "1 135€/mois", 6.0, 24, 4.0),
-  createData("Décile n°2", "1 455€/mois", 9.0, 37, 4.3),
-  createData("Décile n°3", "1 760€/mois", 16.0, 24, 6.0),
-  createData("Décile n°4", "2 115€/mois", 3.7, 67, 4.3),
-  createData("Décile n°5", "2 503€/mois", 16.0, 49, 3.9),
-  createData("Décile n°6", "2 941€/mois", 6.0, 24, 4.0),
-  createData("Décile n°7", "3 440€/mois", 9.0, 37, 4.3),
-  createData("Décile n°8", "4 112€/mois", 16.0, 24, 6.0),
-  createData("Décile n°9", "5 267€/mois", 3.7, 67, 4.3),
-  createData("Décile n°10", "∞€/mois", 16.0, 49, 3.9),
+  createData("Décile n°1", "1 135€/mois", 6.0, 6.0, 24, 24, 24, 4.0),
+  createData("Décile n°2", "1 455€/mois", 9.0, 9.0, 37, 37, 37, 4.3),
+  createData("Décile n°3", "1 760€/mois", 16.0, 16.0, 24, 24, 24, 6.0),
+  createData("Décile n°4", "2 115€/mois", 3.7, 3.7, 67, 67, 67, 4.3),
+  createData("Décile n°5", "2 503€/mois", 16.0, 16.0, 49, 49, 49, 3.9),
+  createData("Décile n°6", "2 941€/mois", 6.0, 6.0, 24, 24, 24, 4.0),
+  createData("Décile n°7", "3 440€/mois", 9.0, 9.0, 37, 37, 37, 4.3),
+  createData("Décile n°8", "4 112€/mois", 16.0, 16.0, 24, 24, 24, 6.0),
+  createData("Décile n°9", "5 267€/mois", 3.7, 3.7, 67, 67, 67, 4.3),
+  createData("Décile n°10", "∞€/mois", 16.0, 16.0, 49, 49, 49, 3.9),
 ];
 
 function SimpopTableurInfosDeciles({ classes }) {
   return (
     <Table>
       <TableHead>
-        <TableRow classeName={classes.tableStyle}>
+        <TableRow className={classes.tableStyle}>
           <TableCell padding="dense">Décile</TableCell>
           <TableCell align="center" padding="dense">
             Salaire net /mois (jusqu&apos;à)
@@ -69,7 +76,7 @@ function SimpopTableurInfosDeciles({ classes }) {
       </TableHead>
       <TableBody>
         {rows.map(row => (
-          <TableRow key={row.id} classeName={classes.tableStyle}>
+          <TableRow key={row.id} className={classes.tableStyle}>
             <TableCell component="th" padding="dense" scope="row">
               {row.decile}
             </TableCell>
@@ -77,10 +84,13 @@ function SimpopTableurInfosDeciles({ classes }) {
               {row.salaire}
             </TableCell>
             <TableCell align="center" padding="dense">
-              {row.impotmoyenfoyer}
+              {row.impactmoyenfoyer_plf}
+              &nbsp;{row.impactmoyenfoyer_reforme}
             </TableCell>
             <TableCell align="center" padding="dense">
-              {row.impactmoyenfoyer}
+              {row.impotmoyenfoyer}
+              &nbsp;{row.impotmoyenfoyer_plf}
+              &nbsp;{row.impotmoyenfoyer_reforme}
             </TableCell>
             <TableCell align="center" padding="dense">
               {row.recettesetat}

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -121,16 +121,16 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
             <b>Décile</b>
           </TableCell>
           <TableCell classes={{root: classes.cellStyle}}>
-            <b>Revenu fiscal de&nbsp;référence</b>
-            <p>(jusqu&apos;à)</p>
+            <b>Revenu&nbsp;fiscal de&nbsp;référence</b>
+            <br/>(jusqu&apos;à)
           </TableCell>
           <TableCell classes={{root: classes.cellStyle}}>
             <b>Impact moyen sur le foyer</b>
-            <p>(par rapport au code existant)</p>
+            <br/>(par rapport au code existant)
           </TableCell>
           <TableCell classes={{root: classes.cellStyle}}>
             <b>Impôt moyen des foyers</b>
-            <p><br/><br/>(par an)</p>
+            <br/>(par an)
           </TableCell>
           <TableCell classes={{root: classes.cellStyle}}>
             <b>Recettes pour l&apos;État</b>

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -1,0 +1,74 @@
+import PropTypes from "prop-types";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import { withStyles } from "@material-ui/core/styles";
+
+const styles = {
+  tableStyle: {
+    height: "0px",
+  },
+  cellStyle: {
+    padding: "0px",
+  },
+}
+
+let id = 0;
+function createData(decile, salaire, impotmoyenfoyer, recettesetat) {
+  id += 1;
+  return {
+    id,
+    decile,
+    salaire,
+    impotmoyenfoyer,
+    recettesetat,
+  };
+}
+
+const rows = [
+  createData("Décile n°1", 159, 6.0, 24, 4.0),
+  createData("Décile n°2", 237, 9.0, 37, 4.3),
+  createData("Décile n°3", 262, 16.0, 24, 6.0),
+  createData("Décile n°4", 305, 3.7, 67, 4.3),
+  createData("Décile n°5", 356, 16.0, 49, 3.9),
+  createData("Décile n°6", 159, 6.0, 24, 4.0),
+  createData("Décile n°7", 237, 9.0, 37, 4.3),
+  createData("Décile n°8", 262, 16.0, 24, 6.0),
+  createData("Décile n°9", 305, 3.7, 67, 4.3),
+  createData("Décile n°10", 356, 16.0, 49, 3.9),
+];
+
+function SimpopTableurInfosDeciles({ classes }) {
+  return (
+    <Table>
+      <TableHead>
+        <TableRow classeName={classes.tableStyle}>
+          <TableCell padding="dense">Décile</TableCell>
+          <TableCell padding="dense" align="center">Salaire net /mois (jusqu&apos;à)</TableCell>
+          <TableCell padding="dense" align="center">Impôt moyen des foyers /an</TableCell>
+          <TableCell padding="dense" align="center">Total des recettes pour l&apos;État</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rows.map(row => (
+          <TableRow classeName={classes.tableStyle} key={row.id}>
+            <TableCell padding="dense" component="th" scope="row">
+              {row.decile}
+            </TableCell>
+            <TableCell padding="dense" align="center">{row.salaire}</TableCell>
+            <TableCell padding="dense" align="center">{row.impotmoyenfoyer}</TableCell>
+            <TableCell padding="dense" align="center">{row.recettesetat}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+SimpopTableurInfosDeciles.propTypes = {
+  classes: PropTypes.shape().isRequired,
+}
+
+export default withStyles(styles)(SimpopTableurInfosDeciles)

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -54,56 +54,68 @@ const styles = {
 let id = 0;
 function createData(
   decile,
-  salaire,
-  impactmoyenfoyer_plf,
-  impactmoyenfoyer_reforme,
-  impotmoyenfoyer,
-  impotmoyenfoyer_plf,
-  impotmoyenfoyer_reforme,
-  recettesetat,
-  recettesetat_plf,
-  recettesetat_reforme,
+  revenuFiscalDeReference,
+  impactMoyenFoyer_plf,
+  impactMoyenFoyer_reforme,
+  impotMoyenFoyer,
+  impotMoyenFoyer_plf,
+  impotMoyenFoyer_reforme,
+  recettesEtat,
+  recettesEtat_plf,
+  recettesEtat_reforme
 ) {
   id += 1;
   return {
     decile,
     id,
-    impactmoyenfoyer_plf,
-    impactmoyenfoyer_reforme,
-    impotmoyenfoyer,
-    impotmoyenfoyer_plf,
-    impotmoyenfoyer_reforme,
-    recettesetat,
-    recettesetat_plf,
-    recettesetat_reforme,
-    salaire,
+    impactMoyenFoyer_plf,
+    impactMoyenFoyer_reforme,
+    impotMoyenFoyer,
+    impotMoyenFoyer_plf,
+    impotMoyenFoyer_reforme,
+    recettesEtat,
+    recettesEtat_plf,
+    recettesEtat_reforme,
+    revenuFiscalDeReference,
   };
 }
 
-// #décile, salaire net/mois, impact foyer (plf, réforme), impôt moyen foyer (existant, plf, réforme), total recettes état
-// source (2016) http://www.senat.fr/rap/l16-140-211/l16-140-2111.pdf
-const frontdec = [
-  3569,
-  9053,
-  12811,
-  16167,
-  19300,
-  23895,
-  29520,
-  37720,
-  52716,
-  "∞",
-];
+
 function create_from_deciles(index, decile) {
+  // source (2016) http://www.senat.fr/rap/l16-140-211/l16-140-2111.pdf
+  const revenusFiscauxDeReference = [
+    3569,
+    9053,
+    12811,
+    16167,
+    19300,
+    23895,
+    29520,
+    37720,
+    52716,
+    "∞",
+  ];
+
+  var impactMoyenFoyer_plf = decile.avant ? Math.round((decile.plf / decile.avant - 1) * 100) : "-";
+  var impactMoyenFoyer_reforme = decile.avant ? Math.round((decile.apres / decile.avant - 1) * 100) : "-";
+  var impotMoyenFoyer = Math.round(decile.avant / decile.poids);
+  var impotMoyenFoyer_plf = Math.round(decile.plf / decile.poids);
+  var impotMoyenFoyer_reforme = Math.round(decile.apres / decile.poids);
+  var recettesEtat = Math.round(decile.avant / 10000000) / 100;
+  var recettesEtat_plf = Math.round(decile.plf / 10000000) / 100;
+  var recettesEtat_reforme = Math.round(decile.apres / 10000000) / 100;
+
   return createData(
     index + 1,
-    `${frontdec[index]}€/an`,
-    decile.avant ? Math.round((decile.plf / decile.avant - 1) * 100) : "-",
-    decile.avant ? Math.round((decile.apres / decile.avant - 1) * 100) : "-",
-    Math.round(decile.avant / decile.poids),
-    Math.round(decile.plf / decile.poids),
-    Math.round(decile.apres / decile.poids),
-    Math.round(decile.apres / 10000000) / 100,
+    revenusFiscauxDeReference[index],
+    impactMoyenFoyer_plf,
+    impactMoyenFoyer_reforme,
+    impotMoyenFoyer,
+    impotMoyenFoyer_plf,
+    impotMoyenFoyer_reforme,
+    recettesEtat,
+    recettesEtat_plf,
+    recettesEtat_reforme
   ); // Les recettes de l'Etat doivent être après réforme?
 }
 
@@ -116,6 +128,7 @@ function imageDecile(id) {
 }
 
 function SimpopTableurInfosDeciles({ classes, deciles }) {
+  console.log(deciles)
   const rows = deciles.map((currElement, index) => create_from_deciles(index, currElement));
   return (
     <Table>
@@ -158,48 +171,43 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
               {imageDecile(row.decile)}
             </TableCell>
             <TableCell align="center" padding="dense">
-              {row.salaire}
+              {row.revenuFiscalDeReference}€/an
             </TableCell>
             <TableCell align="center" padding="dense">
               <span style={styles.plf}>
-                {row.impactmoyenfoyer_plf}
-%
+                {row.impactMoyenFoyer_plf}%
               </span>
               &nbsp;
               <span style={styles.reforme}>
-                {row.impactmoyenfoyer_reforme}
-%
-              </span>
-            </TableCell>
-            <TableCell align="center" padding="dense">
-              <span style={styles.codeExistant}>
-                {row.impotmoyenfoyer}
-€
-              </span>
-              &nbsp;
-              <span style={styles.plf}>
-                {row.impotmoyenfoyer_plf}
-€
-              </span>
-              &nbsp;
-              <span style={styles.reforme}>
-                {row.impotmoyenfoyer_reforme}
-€
+                {row.impactMoyenFoyer_reforme}%
               </span>
             </TableCell>
             <TableCell align="center" padding="dense">
               <span style={styles.codeExistant}>
-                {row.recettesetat}
+                {row.impotMoyenFoyer}€
+              </span>
+              &nbsp;
+              <span style={styles.plf}>
+                {row.impotMoyenFoyer_plf}€
+              </span>
+              &nbsp;
+              <span style={styles.reforme}>
+                {row.impotMoyenFoyer_reforme}€
+              </span>
+            </TableCell>
+            <TableCell align="center" padding="dense">
+              <span style={styles.codeExistant}>
+                {row.recettesEtat}
                 Md€
               </span>
               &nbsp;
               <span style={styles.plf}>
-                {row.recettesetat_plf}
+                {row.recettesEtat_plf}
                 Md€
               </span>
               &nbsp;
               <span style={styles.reforme}>
-                {row.recettesetat_reforme}
+                {row.recettesEtat_reforme}
                 Md€
               </span>
             </TableCell>

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -77,7 +77,7 @@ function createData(
 // source (2016) http://www.senat.fr/rap/l16-140-211/l16-140-2111.pdf
 const frontdec = [3569,9053,12811,16167,19300,23895,29520,37720,52716, "∞"]
 function create_from_deciles(index, decile){
-    return createData("Décile n°" + (index + 1),
+    return createData((index + 1),
       frontdec[index] + "€/an",
       decile["avant"] ? Math.round((decile["plf"]/decile["avant"] -1)*100) : "N/A",
       decile["avant"] ? Math.round((decile["apres"]/decile["avant"] -1)*100) : "N/A",
@@ -85,6 +85,14 @@ function create_from_deciles(index, decile){
       Math.round(decile["plf"]/decile["poids"]),
       Math.round(decile["apres"]/decile["poids"]),
       Math.round(decile["apres"] / 10000000) / 100 ) // Les recettes de l'Etat doivent être après réforme?
+}
+
+function imageDecile(id) {
+  return (
+    <img key={id} alt="" 
+      height="24" width="24"
+      xlinkHref={`/static/images/decile${id}.png`} />
+  );
 }
 
 
@@ -115,7 +123,7 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
         {rows.map(row => (
           <TableRow key={row.id} className={classes.tableStyle}>
             <TableCell component="th" padding="dense" scope="row">
-              {row.decile}
+              {imageDecile(row.decile)}
             </TableCell>
             <TableCell align="center" padding="dense">
               {row.salaire}

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -1,3 +1,4 @@
+import Typography from "@material-ui/core";
 import { withStyles } from "@material-ui/core/styles";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
@@ -22,6 +23,7 @@ const styles = {
     marginRight: "4px",
     padding: "3px",
   },
+
   plf: {
     color: "#FF6B6B",
     fontFamily: "Lato",
@@ -45,6 +47,7 @@ const styles = {
   },
   tableStyle: {
     height: "0px",
+    verticalAlign: "center",
   },
 };
 
@@ -91,12 +94,8 @@ function create_from_deciles(index, decile) {
   return createData(
     index + 1,
     `${frontdec[index]}€/an`,
-    decile.avant
-      ? Math.round((decile.plf / decile.avant - 1) * 100)
-      : "N/A",
-    decile.avant
-      ? Math.round((decile.apres / decile.avant - 1) * 100)
-      : "N/A",
+    decile.avant ? Math.round((decile.plf / decile.avant - 1) * 100) : "N/A",
+    decile.avant ? Math.round((decile.apres / decile.avant - 1) * 100) : "N/A",
     Math.round(decile.avant / decile.poids),
     Math.round(decile.plf / decile.poids),
     Math.round(decile.apres / decile.poids),
@@ -105,16 +104,10 @@ function create_from_deciles(index, decile) {
 }
 
 function imageDecile(id) {
-  var imageId = `imageDecile${id}`;
-  var imagePath = `/static/images/decile${id}.png`;
+  const imageId = `imageDecile${id}`;
+  const imagePath = `/static/images/decile${id}.png`;
   return (
-    <img
-      key={imageId}
-      alt=""
-      height="24"
-      width="24"
-      xlinkHref={imagePath}
-    />
+    <img key={imageId} alt="" height="24" width="24" xlinkHref={imagePath} />
   );
 }
 
@@ -124,18 +117,33 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
     <Table>
       <TableHead>
         <TableRow className={classes.tableStyle}>
-          <TableCell padding="dense">Décile</TableCell>
-          <TableCell align="center" padding="dense">
-            RFR (jusqu&apos;à)
+          <TableCell align="center" padding="none">
+            <p>
+              <b>Décile</b>
+            </p>
           </TableCell>
-          <TableCell align="center" padding="dense">
-            Impact moyen sur le foyer (par rapport au code existant)
+          <TableCell align="center" padding="none">
+            <p>
+              <b>Revenu fiscal de référence</b>
+            </p>
+            <p>(jusqu&apos;à)</p>
           </TableCell>
-          <TableCell align="center" padding="dense">
-            Impôt moyen des foyers /an
+          <TableCell align="center" padding="none">
+            <p>
+              <b>Impact moyen sur le foyer </b>
+            </p>
+            <p>(par rapport au code existant)</p>
           </TableCell>
-          <TableCell align="center" padding="dense">
-            Total des recettes pour l&apos;État
+          <TableCell align="center" padding="none">
+            <p>
+              <b>Impôt moyen des foyers</b>
+            </p>
+            <p>(par an)</p>
+          </TableCell>
+          <TableCell align="center" padding="none">
+            <p>
+              <b>Total des recettes pour l&apos;État</b>
+            </p>
           </TableCell>
         </TableRow>
       </TableHead>
@@ -149,19 +157,35 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
               {row.salaire}
             </TableCell>
             <TableCell align="center" padding="dense">
-              <span style={styles.plf}>{row.impactmoyenfoyer_plf}</span>
+              <span style={styles.plf}>
+                {row.impactmoyenfoyer_plf}
+%
+              </span>
               &nbsp;
-              <span style={styles.reforme}>{row.impactmoyenfoyer_reforme}</span>
+              <span style={styles.reforme}>
+                {row.impactmoyenfoyer_reforme}
+%
+              </span>
             </TableCell>
             <TableCell align="center" padding="dense">
-              <span style={styles.codeExistant}>{row.impotmoyenfoyer}</span>
+              <span style={styles.codeExistant}>
+                {row.impotmoyenfoyer}
+€
+              </span>
               &nbsp;
-              <span style={styles.plf}>{row.impotmoyenfoyer_plf}</span>
+              <span style={styles.plf}>
+                {row.impotmoyenfoyer_plf}
+€
+              </span>
               &nbsp;
-              <span style={styles.reforme}>{row.impotmoyenfoyer_reforme}</span>
+              <span style={styles.reforme}>
+                {row.impotmoyenfoyer_reforme}
+€
+              </span>
             </TableCell>
             <TableCell align="center" padding="dense">
               {row.recettesetat}
+Md€
             </TableCell>
           </TableRow>
         ))}
@@ -172,6 +196,7 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
 
 SimpopTableurInfosDeciles.propTypes = {
   classes: PropTypes.shape().isRequired,
+  deciles: PropTypes.shape().isRequired,
 };
 
 export default withStyles(styles)(SimpopTableurInfosDeciles);

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -7,15 +7,13 @@ import TableRow from "@material-ui/core/TableRow";
 import PropTypes from "prop-types";
 
 const styles = {
-  tableStyle: {
-    height: "0px",
-  },
   cellStyle: {
     padding: "0px",
   },
-  reforme: {
-    borderRadius: "0.3em",
-    color: "#00A3FF",
+  codeExistant: {
+    backgroundColor: "#DED500",
+    backgroundSize: "auto auto",
+    color: "#000000",
     fontFamily: "Lato",
     fontSize: "12px",
     fontWeight: "bold",
@@ -34,10 +32,9 @@ const styles = {
     marginRight: "4px",
     padding: "3px",
   },
-  codeExistant: {
-    backgroundColor: "#DED500",
-    backgroundSize: "auto auto",
-    color: "#000000",
+  reforme: {
+    borderRadius: "0.3em",
+    color: "#00A3FF",
     fontFamily: "Lato",
     fontSize: "12px",
     fontWeight: "bold",
@@ -45,6 +42,9 @@ const styles = {
     marginLeft: "4px",
     marginRight: "4px",
     padding: "3px",
+  },
+  tableStyle: {
+    height: "0px",
   },
 };
 
@@ -61,45 +61,63 @@ function createData(
 ) {
   id += 1;
   return {
-    id,
     decile,
-    salaire,
+    id,
     impactmoyenfoyer_plf,
     impactmoyenfoyer_reforme,
     impotmoyenfoyer,
     impotmoyenfoyer_plf,
     impotmoyenfoyer_reforme,
     recettesetat,
+    salaire,
   };
 }
 
 // #décile, salaire net/mois, impact foyer (plf, réforme), impôt moyen foyer (existant, plf, réforme), total recettes état
 // source (2016) http://www.senat.fr/rap/l16-140-211/l16-140-2111.pdf
-const frontdec = [3569,9053,12811,16167,19300,23895,29520,37720,52716, "∞"]
-function create_from_deciles(index, decile){
-    return createData((index + 1),
-      frontdec[index] + "€/an",
-      decile["avant"] ? Math.round((decile["plf"]/decile["avant"] -1)*100) : "N/A",
-      decile["avant"] ? Math.round((decile["apres"]/decile["avant"] -1)*100) : "N/A",
-      Math.round(decile["avant"]/decile["poids"]),
-      Math.round(decile["plf"]/decile["poids"]),
-      Math.round(decile["apres"]/decile["poids"]),
-      Math.round(decile["apres"] / 10000000) / 100 ) // Les recettes de l'Etat doivent être après réforme?
+const frontdec = [
+  3569,
+  9053,
+  12811,
+  16167,
+  19300,
+  23895,
+  29520,
+  37720,
+  52716,
+  "∞",
+];
+function create_from_deciles(index, decile) {
+  return createData(
+    index + 1,
+    `${frontdec[index]}€/an`,
+    decile.avant
+      ? Math.round((decile.plf / decile.avant - 1) * 100)
+      : "N/A",
+    decile.avant
+      ? Math.round((decile.apres / decile.avant - 1) * 100)
+      : "N/A",
+    Math.round(decile.avant / decile.poids),
+    Math.round(decile.plf / decile.poids),
+    Math.round(decile.apres / decile.poids),
+    Math.round(decile.apres / 10000000) / 100,
+  ); // Les recettes de l'Etat doivent être après réforme?
 }
 
 function imageDecile(id) {
   return (
-    <img key={id} alt="" 
-      height="24" width="24"
-      xlinkHref={`/static/images/decile${id}.png`} />
+    <img
+      key={id}
+      alt=""
+      height="24"
+      width="24"
+      xlinkHref={`/static/images/decile${id}.png`}
+    />
   );
 }
 
-
 function SimpopTableurInfosDeciles({ classes, deciles }) {
-  const rows = deciles.map((currElement, index) => {
-    return create_from_deciles(index, currElement);
-  });
+  const rows = deciles.map((currElement, index) => create_from_deciles(index, currElement));
   return (
     <Table>
       <TableHead>
@@ -130,12 +148,15 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
             </TableCell>
             <TableCell align="center" padding="dense">
               <span style={styles.plf}>{row.impactmoyenfoyer_plf}</span>
-              &nbsp;<span style={styles.reforme}>{row.impactmoyenfoyer_reforme}</span>
+              &nbsp;
+              <span style={styles.reforme}>{row.impactmoyenfoyer_reforme}</span>
             </TableCell>
             <TableCell align="center" padding="dense">
               <span style={styles.codeExistant}>{row.impotmoyenfoyer}</span>
-              &nbsp;<span style={styles.plf}>{row.impotmoyenfoyer_plf}</span>
-              &nbsp;<span style={styles.reforme}>{row.impotmoyenfoyer_reforme}</span>
+              &nbsp;
+              <span style={styles.plf}>{row.impotmoyenfoyer_plf}</span>
+              &nbsp;
+              <span style={styles.reforme}>{row.impotmoyenfoyer_reforme}</span>
             </TableCell>
             <TableCell align="center" padding="dense">
               {row.recettesetat}

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -61,6 +61,8 @@ function createData(
   impotmoyenfoyer_plf,
   impotmoyenfoyer_reforme,
   recettesetat,
+  recettesetat_plf,
+  recettesetat_reforme,
 ) {
   id += 1;
   return {
@@ -72,6 +74,8 @@ function createData(
     impotmoyenfoyer_plf,
     impotmoyenfoyer_reforme,
     recettesetat,
+    recettesetat_plf,
+    recettesetat_reforme,
     salaire,
   };
 }
@@ -94,8 +98,8 @@ function create_from_deciles(index, decile) {
   return createData(
     index + 1,
     `${frontdec[index]}€/an`,
-    decile.avant ? Math.round((decile.plf / decile.avant - 1) * 100) : "N/A",
-    decile.avant ? Math.round((decile.apres / decile.avant - 1) * 100) : "N/A",
+    decile.avant ? Math.round((decile.plf / decile.avant - 1) * 100) : "-",
+    decile.avant ? Math.round((decile.apres / decile.avant - 1) * 100) : "-",
     Math.round(decile.avant / decile.poids),
     Math.round(decile.plf / decile.poids),
     Math.round(decile.apres / decile.poids),
@@ -142,7 +146,7 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
           </TableCell>
           <TableCell align="center" padding="none">
             <p>
-              <b>Total des recettes pour l&apos;État</b>
+              <b>Recettes pour l&apos;État</b>
             </p>
           </TableCell>
         </TableRow>
@@ -184,8 +188,20 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
               </span>
             </TableCell>
             <TableCell align="center" padding="dense">
-              {row.recettesetat}
-Md€
+              <span style={styles.codeExistant}>
+                {row.recettesetat}
+                Md€
+              </span>
+              &nbsp;
+              <span style={styles.plf}>
+                {row.recettesetat_plf}
+                Md€
+              </span>
+              &nbsp;
+              <span style={styles.reforme}>
+                {row.recettesetat_reforme}
+                Md€
+              </span>
             </TableCell>
           </TableRow>
         ))}

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -105,13 +105,15 @@ function create_from_deciles(index, decile) {
 }
 
 function imageDecile(id) {
+  var imageId = `imageDecile${id}`;
+  var imagePath = `/static/images/decile${id}.png`;
   return (
     <img
-      key={id}
+      key={imageId}
       alt=""
       height="24"
       width="24"
-      xlinkHref={`/static/images/decile${id}.png`}
+      xlinkHref={imagePath}
     />
   );
 }

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -111,7 +111,7 @@ function imageDecile(id) {
   const imageId = `imageDecile${id}`;
   const imagePath = `/static/images/decile${id}.png`;
   return (
-    <img key={imageId} alt="" height="24" width="24" xlinkHref={imagePath} />
+    <img key={imageId} alt="" height="24" width="24" src={imagePath} />
   );
 }
 

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -47,7 +47,7 @@ const styles = {
   },
   tableStyle: {
     height: "0px",
-    verticalAlign: "center",
+    verticalAlign: "top",
   },
 };
 

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -1,10 +1,10 @@
-import PropTypes from "prop-types";
+import { withStyles } from "@material-ui/core/styles";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
-import { withStyles } from "@material-ui/core/styles";
+import PropTypes from "prop-types";
 
 const styles = {
   tableStyle: {
@@ -13,31 +13,38 @@ const styles = {
   cellStyle: {
     padding: "0px",
   },
-}
+};
 
 let id = 0;
-function createData(decile, salaire, impotmoyenfoyer, recettesetat) {
+function createData(
+  decile,
+  salaire,
+  impotmoyenfoyer,
+  impactmoyenfoyer,
+  recettesetat,
+) {
   id += 1;
   return {
     id,
     decile,
     salaire,
     impotmoyenfoyer,
+    impactmoyenfoyer,
     recettesetat,
   };
 }
 
 const rows = [
-  createData("Décile n°1", 159, 6.0, 24, 4.0),
-  createData("Décile n°2", 237, 9.0, 37, 4.3),
-  createData("Décile n°3", 262, 16.0, 24, 6.0),
-  createData("Décile n°4", 305, 3.7, 67, 4.3),
-  createData("Décile n°5", 356, 16.0, 49, 3.9),
-  createData("Décile n°6", 159, 6.0, 24, 4.0),
-  createData("Décile n°7", 237, 9.0, 37, 4.3),
-  createData("Décile n°8", 262, 16.0, 24, 6.0),
-  createData("Décile n°9", 305, 3.7, 67, 4.3),
-  createData("Décile n°10", 356, 16.0, 49, 3.9),
+  createData("Décile n°1", "1 135€/mois", 6.0, 24, 4.0),
+  createData("Décile n°2", "1 455€/mois", 9.0, 37, 4.3),
+  createData("Décile n°3", "1 760€/mois", 16.0, 24, 6.0),
+  createData("Décile n°4", "2 115€/mois", 3.7, 67, 4.3),
+  createData("Décile n°5", "2 503€/mois", 16.0, 49, 3.9),
+  createData("Décile n°6", "2 941€/mois", 6.0, 24, 4.0),
+  createData("Décile n°7", "3 440€/mois", 9.0, 37, 4.3),
+  createData("Décile n°8", "4 112€/mois", 16.0, 24, 6.0),
+  createData("Décile n°9", "5 267€/mois", 3.7, 67, 4.3),
+  createData("Décile n°10", "∞€/mois", 16.0, 49, 3.9),
 ];
 
 function SimpopTableurInfosDeciles({ classes }) {
@@ -46,29 +53,47 @@ function SimpopTableurInfosDeciles({ classes }) {
       <TableHead>
         <TableRow classeName={classes.tableStyle}>
           <TableCell padding="dense">Décile</TableCell>
-          <TableCell padding="dense" align="center">Salaire net /mois (jusqu&apos;à)</TableCell>
-          <TableCell padding="dense" align="center">Impôt moyen des foyers /an</TableCell>
-          <TableCell padding="dense" align="center">Total des recettes pour l&apos;État</TableCell>
+          <TableCell align="center" padding="dense">
+            Salaire net /mois (jusqu&apos;à)
+          </TableCell>
+          <TableCell align="center" padding="dense">
+            Impact moyen sur le foyer (par rapport au code existant)
+          </TableCell>
+          <TableCell align="center" padding="dense">
+            Impôt moyen des foyers /an
+          </TableCell>
+          <TableCell align="center" padding="dense">
+            Total des recettes pour l&apos;État
+          </TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
         {rows.map(row => (
-          <TableRow classeName={classes.tableStyle} key={row.id}>
-            <TableCell padding="dense" component="th" scope="row">
+          <TableRow key={row.id} classeName={classes.tableStyle}>
+            <TableCell component="th" padding="dense" scope="row">
               {row.decile}
             </TableCell>
-            <TableCell padding="dense" align="center">{row.salaire}</TableCell>
-            <TableCell padding="dense" align="center">{row.impotmoyenfoyer}</TableCell>
-            <TableCell padding="dense" align="center">{row.recettesetat}</TableCell>
+            <TableCell align="center" padding="dense">
+              {row.salaire}
+            </TableCell>
+            <TableCell align="center" padding="dense">
+              {row.impotmoyenfoyer}
+            </TableCell>
+            <TableCell align="center" padding="dense">
+              {row.impactmoyenfoyer}
+            </TableCell>
+            <TableCell align="center" padding="dense">
+              {row.recettesetat}
+            </TableCell>
           </TableRow>
         ))}
       </TableBody>
     </Table>
-  )
+  );
 }
 
 SimpopTableurInfosDeciles.propTypes = {
   classes: PropTypes.shape().isRequired,
-}
+};
 
-export default withStyles(styles)(SimpopTableurInfosDeciles)
+export default withStyles(styles)(SimpopTableurInfosDeciles);

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -8,15 +8,17 @@ import TableRow from "@material-ui/core/TableRow";
 import PropTypes from "prop-types";
 
 const styles = {
-  titleCarteEtat: {
+  tableHeader: {
     color: "#565656",
     fontFamily: "Lato",
     fontSize: "1.125em",
-    fontWeight: "bold",
-    padding: "0 0 0 10px",
+    height: "0px",
+    verticalAlign: "top",
+    textAlign: "center",
   },
   cellStyle: {
-    padding: "0px",
+    padding: "0.6em",
+    textAlign: "center",
   },
   codeExistant: {
     backgroundColor: "#DED500",
@@ -50,10 +52,6 @@ const styles = {
     marginLeft: "4px",
     marginRight: "4px",
     padding: "3px",
-  },
-  tableStyle: {
-    height: "0px",
-    verticalAlign: "top",
   },
 };
 
@@ -118,47 +116,37 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
   return (
     <Table>
       <TableHead>
-        <TableRow className={classes.titleCarteEtat, classes.tableStyle}>
-          <TableCell align="center" padding="none">
-            <p>
-              <b>Décile</b>
-            </p>
+        <TableRow classes={{root: classes.tableHeader}}>
+          <TableCell classes={{root: classes.cellStyle}}>
+            <b>Décile</b>
           </TableCell>
-          <TableCell align="center" padding="none">
-            <p>
-              <b>Revenu fiscal de référence</b>
-            </p>
+          <TableCell classes={{root: classes.cellStyle}}>
+            <b>Revenu fiscal de&nbsp;référence</b>
             <p>(jusqu&apos;à)</p>
           </TableCell>
-          <TableCell align="center" padding="none">
-            <p>
-              <b>Impact moyen sur le foyer</b>
-            </p>
+          <TableCell classes={{root: classes.cellStyle}}>
+            <b>Impact moyen sur le foyer</b>
             <p>(par rapport au code existant)</p>
           </TableCell>
-          <TableCell align="center" padding="none">
-            <p>
-              <b>Impôt moyen des foyers</b>
-            </p>
+          <TableCell classes={{root: classes.cellStyle}}>
+            <b>Impôt moyen des foyers</b>
             <p>(par an)</p>
           </TableCell>
-          <TableCell align="center" padding="none">
-            <p>
-              <b>Recettes pour l&apos;État</b>
-            </p>
+          <TableCell classes={{root: classes.cellStyle}}>
+            <b>Recettes pour l&apos;État</b>
           </TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
         {rows.map(row => (
-          <TableRow key={row.id} className={classes.tableStyle}>
-            <TableCell component="th" padding="dense" scope="row">
+          <TableRow key={row.id}>
+            <TableCell classes={{root: classes.cellStyle}}>
               {imageDecile(row.decile)}
             </TableCell>
-            <TableCell align="center" padding="dense">
+            <TableCell classes={{root: classes.cellStyle}}>
               {row.revenuFiscalDeReference}€/an
             </TableCell>
-            <TableCell align="center" padding="dense">
+            <TableCell classes={{root: classes.cellStyle}}>
               <span style={styles.plf}>
                 {(row.impactMoyenFoyer_plf == "-") ? NON_APPLICABLE : row.impactMoyenFoyer_plf+"%"}
               </span>
@@ -167,7 +155,7 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
                 {(row.impactMoyenFoyer_reforme == "-") ? NON_APPLICABLE : row.impactMoyenFoyer_reforme+"%"}
               </span>
             </TableCell>
-            <TableCell align="center" padding="dense">
+            <TableCell classes={{root: classes.cellStyle}}>
               <span style={styles.codeExistant}>
                 {row.impotMoyenFoyer}€
               </span>
@@ -180,20 +168,17 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
                 {row.impotMoyenFoyer_reforme}€
               </span>
             </TableCell>
-            <TableCell align="center" padding="dense">
+            <TableCell classes={{root: classes.cellStyle}}>
               <span style={styles.codeExistant}>
-                {row.recettesEtat}
-                Md€
+                {row.recettesEtat}Md€
               </span>
               &nbsp;
               <span style={styles.plf}>
-                {row.recettesEtat_plf}
-                Md€
+                {row.recettesEtat_plf}Md€
               </span>
               &nbsp;
               <span style={styles.reforme}>
-                {row.recettesEtat_reforme}
-                Md€
+                {row.recettesEtat_reforme}Md€
               </span>
             </TableCell>
           </TableRow>

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -74,20 +74,18 @@ function createData(
 }
 
 // #décile, salaire net/mois, impact foyer (plf, réforme), impôt moyen foyer (existant, plf, réforme), total recettes état
-const rows = [
-  createData("Décile n°1", "1 135€/mois", 6.0, 6.0, 24, 24, 24, 4.0),
-  createData("Décile n°2", "1 455€/mois", 9.0, 9.0, 37, 37, 37, 4.3),
-  createData("Décile n°3", "1 760€/mois", 16.0, 16.0, 24, 24, 24, 6.0),
-  createData("Décile n°4", "2 115€/mois", 3.7, 3.7, 67, 67, 67, 4.3),
-  createData("Décile n°5", "2 503€/mois", 16.0, 16.0, 49, 49, 49, 3.9),
-  createData("Décile n°6", "2 941€/mois", 6.0, 6.0, 24, 24, 24, 4.0),
-  createData("Décile n°7", "3 440€/mois", 9.0, 9.0, 37, 37, 37, 4.3),
-  createData("Décile n°8", "4 112€/mois", 16.0, 16.0, 24, 24, 24, 6.0),
-  createData("Décile n°9", "5 267€/mois", 3.7, 3.7, 67, 67, 67, 4.3),
-  createData("Décile n°10", "∞€/mois", 16.0, 16.0, 49, 49, 49, 3.9),
-];
 
-function SimpopTableurInfosDeciles({ classes }) {
+const frontdec = [1000,20000,3000,4000,5000,6000,7000,8000,9000, 9999999999999]
+function create_from_deciles(index, decile){
+    return createData("Décile n°" + index, frontdec[index] + "€/mois", decile["avant"] ? Math.round((decile["apres"]/decile["avant"] -1)*100) : "N/A", 6.0, 24, 24, 24, 4.0 )
+}
+
+
+function SimpopTableurInfosDeciles({ classes, deciles }) {
+  console.log("maprop", deciles);
+  const rows = deciles.map((currElement, index) => {
+    return create_from_deciles(index, currElement);
+  });
   return (
     <Table>
       <TableHead>

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -130,7 +130,7 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
           </TableCell>
           <TableCell classes={{root: classes.cellStyle}}>
             <b>Impôt moyen des foyers</b>
-            <p>(par an)</p>
+            <p><br/><br/>(par an)</p>
           </TableCell>
           <TableCell classes={{root: classes.cellStyle}}>
             <b>Recettes pour l&apos;État</b>

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -13,6 +13,39 @@ const styles = {
   cellStyle: {
     padding: "0px",
   },
+  reforme: {
+    borderRadius: "0.3em",
+    color: "#00A3FF",
+    fontFamily: "Lato",
+    fontSize: "12px",
+    fontWeight: "bold",
+    lineHeight: "10px",
+    marginLeft: "4px",
+    marginRight: "4px",
+    padding: "3px",
+  },
+  plf: {
+    color: "#FF6B6B",
+    fontFamily: "Lato",
+    fontSize: "12px",
+    fontWeight: "bold",
+    lineHeight: "10px",
+    marginLeft: "4px",
+    marginRight: "4px",
+    padding: "3px",
+  },
+  codeExistant: {
+    backgroundColor: "#DED500",
+    backgroundSize: "auto auto",
+    color: "#000000",
+    fontFamily: "Lato",
+    fontSize: "12px",
+    fontWeight: "bold",
+    lineHeight: "10px",
+    marginLeft: "4px",
+    marginRight: "4px",
+    padding: "3px",
+  },
 };
 
 let id = 0;
@@ -84,13 +117,13 @@ function SimpopTableurInfosDeciles({ classes }) {
               {row.salaire}
             </TableCell>
             <TableCell align="center" padding="dense">
-              {row.impactmoyenfoyer_plf}
-              &nbsp;{row.impactmoyenfoyer_reforme}
+              <span style={styles.plf}>{row.impactmoyenfoyer_plf}</span>
+              &nbsp;<span style={styles.reforme}>{row.impactmoyenfoyer_reforme}</span>
             </TableCell>
             <TableCell align="center" padding="dense">
-              {row.impotmoyenfoyer}
-              &nbsp;{row.impotmoyenfoyer_plf}
-              &nbsp;{row.impotmoyenfoyer_reforme}
+              <span style={styles.codeExistant}>{row.impotmoyenfoyer}</span>
+              &nbsp;<span style={styles.plf}>{row.impotmoyenfoyer_plf}</span>
+              &nbsp;<span style={styles.reforme}>{row.impotmoyenfoyer_reforme}</span>
             </TableCell>
             <TableCell align="center" padding="dense">
               {row.recettesetat}

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -117,8 +117,8 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
   const NON_APPLICABLE = "—";
   return (
     <Table>
-      <TableHead className={classes.titleCarteEtat}>
-        <TableRow className={classes.tableStyle}>
+      <TableHead>
+        <TableRow className={classes.titleCarteEtat, classes.tableStyle}>
           <TableCell align="center" padding="none">
             <p>
               <b>Décile</b>

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -74,10 +74,17 @@ function createData(
 }
 
 // #décile, salaire net/mois, impact foyer (plf, réforme), impôt moyen foyer (existant, plf, réforme), total recettes état
-
-const frontdec = [1000,20000,3000,4000,5000,6000,7000,8000,9000, 9999999999999]
+// source (2016) http://www.senat.fr/rap/l16-140-211/l16-140-2111.pdf
+const frontdec = [3569,9053,12811,16167,19300,23895,29520,37720,52716, "∞"]
 function create_from_deciles(index, decile){
-    return createData("Décile n°" + index, frontdec[index] + "€/mois", decile["avant"] ? Math.round((decile["apres"]/decile["avant"] -1)*100) : "N/A", 6.0, 24, 24, 24, 4.0 )
+    return createData("Décile n°" + (index + 1),
+      frontdec[index] + "€/mois",
+      decile["avant"] ? Math.round((decile["plf"]/decile["avant"] -1)*100) : "N/A",
+      decile["avant"] ? Math.round((decile["apres"]/decile["avant"] -1)*100) : "N/A",
+      Math.round(decile["avant"]/decile["poids"]),
+      Math.round(decile["plf"]/decile["poids"]),
+      Math.round(decile["apres"]/decile["poids"]),
+      Math.round(decile["apres"] / 10000000) / 100 ) // Les recettes de l'Etat doivent être après réforme?
 }
 
 

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -33,7 +33,6 @@ input.mui-number-stepper::-webkit-outer-spin-button {
     margin-right: 32px;
     margin-top: 1em;
     float: left;
-    width: 34.7em;
   }
 }
 

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -24,7 +24,6 @@ input.mui-number-stepper::-webkit-outer-spin-button {
     box-sizing: border-box;
     position: absolute;
     width: 600px;
-
     float: left;
   }
 
@@ -34,6 +33,7 @@ input.mui-number-stepper::-webkit-outer-spin-button {
     margin-right: 32px;
     margin-top: 1em;
     float: left;
+    width: 34.7em;
   }
 }
 


### PR DESCRIPTION
@magemax Voilà ce que j'ai réussi à faire jusqu'à aujourd'hui.

Pour repère : une esquisse de ce que pourrait donner le tableur. Il manque la colonne finale sur les recettes pour l'État au total par déciles

<img width="861" alt="Capture d’écran 2019-09-18 à 14 11 50" src="https://user-images.githubusercontent.com/46896006/65147053-9201a980-da1d-11e9-8bc6-a2179b5a0c92.png">
