### PR TITLE
retour des sexes aléatoires pour les cas types par défaut : les cas types créés par les usagers restent customisés par eux-mêmes.

### DIFF
--- a/components/ajouter-cas-types/form/cas-types-person.jsx
+++ b/components/ajouter-cas-types/form/cas-types-person.jsx
@@ -39,7 +39,7 @@ class CasTypesPerson extends PureComponent {
     const {
       classes, isChild, max, min, name,
     } = this.props;
-    let icon = Math.random() < 0.15 ? manCurlyHaired : womanCurlyHaired;
+    let icon = Math.random() < 0.5 ? manCurlyHaired : womanCurlyHaired;
     if (isChild) {
       icon = babyIcon;
     }

--- a/components/utils/transform-data-to-cas-types.js
+++ b/components/utils/transform-data-to-cas-types.js
@@ -63,14 +63,19 @@ export const transformDataToCasTypes = datas => datas.map((data) => {
       invalide: get(data, "nb_pac_invalides") || 0,
     },
   );
-
-  const parents = createPersons(
+  //First person is randomized
+  var nbgender= ((Math.random()>0.5) ? 1 : 0);
+  //If several persons : determines whether or not same emoji-sex couple
+  if (nbCouple>1) {
+    nbgender = (Math.random()<0.15) ? 2*nbgender:1;
+  }
+  const baseparents = createPersons(
     nbCouple,
     data,
     {
       ancienCombattant: 0,
       chargePartagee: 0,
-      gender: generateRandomGender(),
+      gender: 0,
       invalide: 0,
       isChild: 0,
       parentIsole: 0,
@@ -79,12 +84,14 @@ export const transformDataToCasTypes = datas => datas.map((data) => {
     },
     {
       ancienCombattant: get(data, "nb_anciens_combattants") || 0,
+      gender: nbgender,
       invalide: get(data, "nb_decl_invalides") || 0,
       parentIsole: get(data, "nb_decl_parent_isole") || 0,
       plus65ans: get(data, "nombre_declarants_retraites") || 0,
       veufVeuve: get(data, "nb_decl_veuf") || 0,
     },
   );
+  const parents = Math.random()<0.5? baseparents:baseparents.reverse()
 
   return {
     lieuResidence,


### PR DESCRIPTION
Eh oui, c'est le grand retour des couples hétérosexuels. 

@DorineLam   Bien checker que c'est ce que tu avais en tête. Par simplicité, j'ai juste changé les cas types par défaut (les genre des gens sont tirés au sort une seule fois au moment du loading de la page).  
