### PR TITLE
Emploie les frontières déciles du serveur

### DIFF
--- a/components/articles/articles-component.jsx
+++ b/components/articles/articles-component.jsx
@@ -137,7 +137,6 @@ class ArticlesComponent extends React.Component {
   );
 
   gimmeIRPartsOfArticle = (i) => {
-    //  console.log("coucou");
     const {
       handleArticleChange,
       reforme,
@@ -157,7 +156,6 @@ class ArticlesComponent extends React.Component {
     if (i === 0) {
       const baseValue = bases[Math.min(i, bases.length - 1)];
       const plfValue = plfs[Math.min(i, plfs.length - 1)];
-      console.log(baseValue,plfValue,Math.abs(baseValue-plfValue) < 0.001);
       return (
         <Typography
           key={i}

--- a/components/articles/legende-article/legende-article.jsx
+++ b/components/articles/legende-article/legende-article.jsx
@@ -87,7 +87,7 @@ function LegendeArticle({ classes }) {
           className={classes.alink}
           href="http://www.assemblee-nationale.fr/15/projets/pl2272.asp"
           target="blank">
-          Modifications d&apos;impôt prévues en 2020
+          PLF 2020
           <OpenInNewIcon className={classes.styleOpenInNewIcon} />
         </a>
       </Typography>

--- a/components/carte-etat/carte-etat-component.jsx
+++ b/components/carte-etat/carte-etat-component.jsx
@@ -220,6 +220,7 @@ CarteEtat.propTypes = {
       poids: PropTypes.number.isRequired,
     }).isRequired,
   ).isRequired,
+  frontieres_deciles: PropTypes.bool.isRequired,
   isDisabledEtat: PropTypes.bool.isRequired,
   isLoadingEtat: PropTypes.bool.isRequired,
   onClickSimPop: PropTypes.func.isRequired,

--- a/components/carte-etat/carte-etat-component.jsx
+++ b/components/carte-etat/carte-etat-component.jsx
@@ -96,6 +96,7 @@ class CarteEtat extends PureComponent {
     const {
       classes,
       deciles,
+      frontieres_deciles,
       expandArticlePanelHandler,
       isDisabledEtat,
       isLoadingEtat,
@@ -182,7 +183,7 @@ class CarteEtat extends PureComponent {
                     * Chiffrages indicatifs.
                     <br />
                     {" "}
-Estimation à partir des données de l&apos;Enquête
+                    Estimation à partir des données de l&apos;Enquête
                     Revenus Fiscaux et Sociaux de l&apos;INSEE.
                   </Typography>
                 </div>
@@ -201,7 +202,7 @@ Estimation à partir des données de l&apos;Enquête
             </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails className="styleExpansionPanel">
-            <SimpopTableurInfosDeciles deciles={deciles} />
+            <SimpopTableurInfosDeciles deciles={deciles} frontieres_deciles={frontieres_deciles}/>
           </ExpansionPanelDetails>
         </ExpansionPanel>
       </Card>

--- a/components/carte-etat/index.js
+++ b/components/carte-etat/index.js
@@ -7,8 +7,6 @@ const mapStateToProps = ({ loadingEtat, totalPop }) => {
   const isLoadingEtat = loadingEtat === "loading";
   const isDisabledEtat = loadingEtat === "disabled";
   const { deciles, frontieres_deciles, total } = totalPop;
-  console.log("carte-etat > index.js")
-  console.log(totalPop)
   return {
     deciles,
     frontieres_deciles,

--- a/components/carte-etat/index.js
+++ b/components/carte-etat/index.js
@@ -6,9 +6,12 @@ import CarteEtatComponent from "./carte-etat-component";
 const mapStateToProps = ({ loadingEtat, totalPop }) => {
   const isLoadingEtat = loadingEtat === "loading";
   const isDisabledEtat = loadingEtat === "disabled";
-  const { deciles, total } = totalPop;
+  const { deciles, frontieres_deciles, total } = totalPop;
+  console.log("carte-etat > index.js")
+  console.log(totalPop)
   return {
     deciles,
+    frontieres_deciles,
     isDisabledEtat,
     isLoadingEtat,
     total,

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -116,7 +116,7 @@ function SimpopTableurInfosDeciles({ classes, deciles, frontieres_deciles }) {
           </TableCell>
           <TableCell classes={{root: classes.cellStyle}}>
             <b>Revenu&nbsp;fiscal de&nbsp;référence</b>
-            <br/>(jusqu&apos;à)
+            <br/>(limite supérieure)
           </TableCell>
           <TableCell classes={{root: classes.cellStyle}}>
             <b>Impact moyen sur le foyer</b>

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -84,7 +84,7 @@ function create_from_deciles(index, decile, frontiereDecile) {
   var recettesEtat = Math.round(decile.avant / 10000000) / 100;
   var recettesEtat_plf = Math.round(decile.plf / 10000000) / 100;
   var recettesEtat_reforme = Math.round(decile.apres / 10000000) / 100;
-  var frontiere = (index+1 < NOMBRE_DECILES) ? Math.round(frontiereDecile) : "∞";
+  var frontiere = (index+1 < NOMBRE_DECILES) ? Math.round(frontiereDecile) : ("∞\u00a0");
 
   return createData(
     index + 1,

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -20,6 +20,11 @@ const styles = {
     padding: "0.6em",
     textAlign: "center",
   },
+  infinity: {
+    fontSize: "1.5em",
+    fontWeight: "330",
+    verticalAlign: "sub",
+  },
   codeExistant: {
     backgroundColor: "#DED500",
     backgroundSize: "auto auto",
@@ -84,7 +89,7 @@ function create_from_deciles(index, decile, frontiereDecile) {
   var recettesEtat = Math.round(decile.avant / 10000000) / 100;
   var recettesEtat_plf = Math.round(decile.plf / 10000000) / 100;
   var recettesEtat_reforme = Math.round(decile.apres / 10000000) / 100;
-  var frontiere = (index+1 < NOMBRE_DECILES) ? Math.round(frontiereDecile) : ("∞\u00a0");
+  var frontiere = (index+1 < NOMBRE_DECILES) ? Math.round(frontiereDecile) : "-";
 
   return createData(
     index + 1,
@@ -138,7 +143,7 @@ function SimpopTableurInfosDeciles({ classes, deciles, frontieres_deciles }) {
               {imageDecile(row.decile)}
             </TableCell>
             <TableCell classes={{root: classes.cellStyle}}>
-              &#10877;&nbsp;{row.frontiereDecile}€/an
+              &#10877;&nbsp;{(row.frontiereDecile == "-") ? <span className={classes.infinity}>∞&nbsp;</span> : row.frontiereDecile}€/an
             </TableCell>
             <TableCell classes={{root: classes.cellStyle}}>
               <span style={styles.plf}>

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -133,6 +133,7 @@ function SimpopTableurInfosDeciles({ classes, deciles, frontieres_deciles }) {
           </TableCell>
           <TableCell classes={{root: classes.cellStyle}}>
             <b>Recettes pour l&apos;État</b>
+            <br/>(en Millions d'Euros)
           </TableCell>
         </TableRow>
       </TableHead>

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -21,7 +21,7 @@ const styles = {
     textAlign: "center",
   },
   infinity: {
-    fontSize: "1.5em",
+    fontSize: "2em",
     fontWeight: "330",
     verticalAlign: "sub",
   },
@@ -60,52 +60,69 @@ const styles = {
   },
 };
 
-const NOMBRE_DECILES = 10
+const NOMBRE_DECILES = 10;
 let id = 0;
 function createData(
   decile,
   frontiereDecile,
-  impactMoyenFoyer_plf, impactMoyenFoyer_reforme,
-  impotMoyenFoyer, impotMoyenFoyer_plf, impotMoyenFoyer_reforme,
-  recettesEtat, recettesEtat_plf, recettesEtat_reforme
+  impactMoyenFoyer_plf,
+  impactMoyenFoyer_reforme,
+  impotMoyenFoyer,
+  impotMoyenFoyer_plf,
+  impotMoyenFoyer_reforme,
+  recettesEtat,
+  recettesEtat_plf,
+  recettesEtat_reforme,
 ) {
   id += 1;
   return {
     decile,
     id,
-    impactMoyenFoyer_plf, impactMoyenFoyer_reforme,
-    impotMoyenFoyer, impotMoyenFoyer_plf, impotMoyenFoyer_reforme,
-    recettesEtat, recettesEtat_plf, recettesEtat_reforme,
+    impactMoyenFoyer_plf,
+    impactMoyenFoyer_reforme,
+    impotMoyenFoyer,
+    impotMoyenFoyer_plf,
+    impotMoyenFoyer_reforme,
+    recettesEtat,
+    recettesEtat_plf,
+    recettesEtat_reforme,
     frontiereDecile,
   };
 }
 
 function create_from_deciles(index, decile, frontiereDecile) {
-  var impactMoyenFoyer_plf = decile.avant ? Math.round((decile.plf / decile.avant - 1) * 100) : "-";
-  var impactMoyenFoyer_reforme = decile.avant ? Math.round((decile.apres / decile.avant - 1) * 100) : "-";
-  var impotMoyenFoyer = Math.round(decile.avant / decile.poids);
-  var impotMoyenFoyer_plf = Math.round(decile.plf / decile.poids);
-  var impotMoyenFoyer_reforme = Math.round(decile.apres / decile.poids);
-  var recettesEtat = Math.round(decile.avant / 10000000) / 100;
-  var recettesEtat_plf = Math.round(decile.plf / 10000000) / 100;
-  var recettesEtat_reforme = Math.round(decile.apres / 10000000) / 100;
-  var frontiere = (index+1 < NOMBRE_DECILES) ? Math.round(frontiereDecile) : "-";
+  const impactMoyenFoyer_plf = decile.avant
+    ? Math.round((decile.plf / decile.avant - 1) * 100)
+    : "-";
+  const impactMoyenFoyer_reforme = decile.avant
+    ? Math.round((decile.apres / decile.avant - 1) * 100)
+    : "-";
+  const impotMoyenFoyer = Math.round(decile.avant / decile.poids);
+  const impotMoyenFoyer_plf = Math.round(decile.plf / decile.poids);
+  const impotMoyenFoyer_reforme = Math.round(decile.apres / decile.poids);
+  const recettesEtat = Math.round(decile.avant / 10000000) / 100;
+  const recettesEtat_plf = Math.round(decile.plf / 10000000) / 100;
+  const recettesEtat_reforme = Math.round(decile.apres / 10000000) / 100;
+  const frontiere = index + 1 < NOMBRE_DECILES ? Math.round(frontiereDecile) : "-";
 
   return createData(
     index + 1,
     frontiere,
-    impactMoyenFoyer_plf, impactMoyenFoyer_reforme,
-    impotMoyenFoyer, impotMoyenFoyer_plf, impotMoyenFoyer_reforme,
-    recettesEtat, recettesEtat_plf, recettesEtat_reforme
+    impactMoyenFoyer_plf,
+    impactMoyenFoyer_reforme,
+    impotMoyenFoyer,
+    impotMoyenFoyer_plf,
+    impotMoyenFoyer_reforme,
+    recettesEtat,
+    recettesEtat_plf,
+    recettesEtat_reforme,
   );
 }
 
 function imageDecile(id) {
   const imageId = `imageDecile${id}`;
   const imagePath = `/static/images/decile${id}.png`;
-  return (
-    <img key={imageId} alt="" height="24" width="24" src={imagePath} />
-  );
+  return <img key={imageId} alt="" height="24" src={imagePath} width="24" />;
 }
 
 function SimpopTableurInfosDeciles({ classes, deciles, frontieres_deciles }) {
@@ -115,70 +132,90 @@ function SimpopTableurInfosDeciles({ classes, deciles, frontieres_deciles }) {
   return (
     <Table>
       <TableHead>
-        <TableRow classes={{root: classes.tableHeader}}>
-          <TableCell classes={{root: classes.cellStyle}}>
+        <TableRow classes={{ root: classes.tableHeader }}>
+          <TableCell classes={{ root: classes.cellStyle }}>
             <b>Décile</b>
           </TableCell>
-          <TableCell classes={{root: classes.cellStyle}}>
+          <TableCell classes={{ root: classes.cellStyle }}>
             <b>Revenu&nbsp;fiscal de&nbsp;référence</b>
-            <br/>(limite supérieure)
+            <br />
+            (limite supérieure)
           </TableCell>
-          <TableCell classes={{root: classes.cellStyle}}>
+          <TableCell classes={{ root: classes.cellStyle }}>
             <b>Impact moyen sur le foyer</b>
-            <br/>(par rapport au code existant)
+            <br />
+            (par rapport au code existant)
           </TableCell>
-          <TableCell classes={{root: classes.cellStyle}}>
+          <TableCell classes={{ root: classes.cellStyle }}>
             <b>Impôt moyen des foyers</b>
-            <br/>(par an)
+            <br />
+            (par an)
           </TableCell>
-          <TableCell classes={{root: classes.cellStyle}}>
+          <TableCell classes={{ root: classes.cellStyle }}>
             <b>Recettes pour l&apos;État</b>
-            <br/>(en Millions d&apos;Euros)
+            <br />
+            (en Milliards d&apos;euros)
           </TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
         {rows.map(row => (
           <TableRow key={row.id}>
-            <TableCell classes={{root: classes.cellStyle}}>
+            <TableCell classes={{ root: classes.cellStyle }}>
               {imageDecile(row.decile)}
             </TableCell>
-            <TableCell classes={{root: classes.cellStyle}}>
-              &#10877;&nbsp;{(row.frontiereDecile == "-") ? <span className={classes.infinity}>∞&nbsp;</span> : row.frontiereDecile}€/an
+            <TableCell classes={{ root: classes.cellStyle }}>
+              &#10877;&nbsp;
+              {row.frontiereDecile == "-" ? (
+                <span className={classes.infinity}>∞</span>
+              ) : (
+                row.frontiereDecile
+              )}
+              €/an
             </TableCell>
-            <TableCell classes={{root: classes.cellStyle}}>
+            <TableCell classes={{ root: classes.cellStyle }}>
               <span style={styles.plf}>
-                {(row.impactMoyenFoyer_plf == "-") ? NON_APPLICABLE : row.impactMoyenFoyer_plf+"%"}
+                {row.impactMoyenFoyer_plf == "-"
+                  ? NON_APPLICABLE
+                  : `${row.impactMoyenFoyer_plf}%`}
               </span>
               &nbsp;
               <span style={styles.reforme}>
-                {(row.impactMoyenFoyer_reforme == "-") ? NON_APPLICABLE : row.impactMoyenFoyer_reforme+"%"}
+                {row.impactMoyenFoyer_reforme == "-"
+                  ? NON_APPLICABLE
+                  : `${row.impactMoyenFoyer_reforme}%`}
               </span>
             </TableCell>
-            <TableCell classes={{root: classes.cellStyle}}>
+            <TableCell classes={{ root: classes.cellStyle }}>
               <span style={styles.codeExistant}>
-                {row.impotMoyenFoyer}€
+                {row.impotMoyenFoyer}
+€
               </span>
               &nbsp;
               <span style={styles.plf}>
-                {row.impotMoyenFoyer_plf}€
+                {row.impotMoyenFoyer_plf}
+€
               </span>
               &nbsp;
               <span style={styles.reforme}>
-                {row.impotMoyenFoyer_reforme}€
+                {row.impotMoyenFoyer_reforme}
+€
               </span>
             </TableCell>
-            <TableCell classes={{root: classes.cellStyle}}>
+            <TableCell classes={{ root: classes.cellStyle }}>
               <span style={styles.codeExistant}>
-                {row.recettesEtat}Md€
+                {row.recettesEtat}
+                Md€
               </span>
               &nbsp;
               <span style={styles.plf}>
-                {row.recettesEtat_plf}Md€
+                {row.recettesEtat_plf}
+                Md€
               </span>
               &nbsp;
               <span style={styles.reforme}>
-                {row.recettesEtat_reforme}Md€
+                {row.recettesEtat_reforme}
+                Md€
               </span>
             </TableCell>
           </TableRow>

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -189,17 +189,17 @@ function SimpopTableurInfosDeciles({ classes, deciles, frontieres_deciles }) {
             <TableCell classes={{ root: classes.cellStyle }}>
               <span style={styles.codeExistant}>
                 {row.impotMoyenFoyer}
-€
+                €
               </span>
               &nbsp;
               <span style={styles.plf}>
                 {row.impotMoyenFoyer_plf}
-€
+                €
               </span>
               &nbsp;
               <span style={styles.reforme}>
                 {row.impotMoyenFoyer_reforme}
-€
+                €
               </span>
             </TableCell>
             <TableCell classes={{ root: classes.cellStyle }}>

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -55,6 +55,7 @@ const styles = {
   },
 };
 
+const NOMBRE_DECILES = 10
 let id = 0;
 function createData(
   decile,
@@ -83,7 +84,7 @@ function create_from_deciles(index, decile, frontiereDecile) {
   var recettesEtat = Math.round(decile.avant / 10000000) / 100;
   var recettesEtat_plf = Math.round(decile.plf / 10000000) / 100;
   var recettesEtat_reforme = Math.round(decile.apres / 10000000) / 100;
-  var frontiere = Math.round(frontiereDecile)
+  var frontiere = (index+1 < NOMBRE_DECILES) ? Math.round(frontiereDecile) : "∞";
 
   return createData(
     index + 1,

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -110,7 +110,7 @@ function imageDecile(id) {
   );
 }
 
-function SimpopTableurInfosDeciles({ classes, deciles }) {
+function SimpopTableurInfosDeciles({ classes, deciles, frontieres_deciles }) {
   const rows = deciles.map((currElement, index) => create_from_deciles(index, currElement));
   const NON_APPLICABLE = "—";
   return (
@@ -191,6 +191,7 @@ function SimpopTableurInfosDeciles({ classes, deciles }) {
 SimpopTableurInfosDeciles.propTypes = {
   classes: PropTypes.shape().isRequired,
   deciles: PropTypes.shape().isRequired,
+  frontieres_deciles: PropTypes.shape().isRequired,
 };
 
 export default withStyles(styles)(SimpopTableurInfosDeciles);

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -58,7 +58,7 @@ const styles = {
 let id = 0;
 function createData(
   decile,
-  revenuFiscalDeReference,
+  frontiereDecile,
   impactMoyenFoyer_plf, impactMoyenFoyer_reforme,
   impotMoyenFoyer, impotMoyenFoyer_plf, impotMoyenFoyer_reforme,
   recettesEtat, recettesEtat_plf, recettesEtat_reforme
@@ -70,20 +70,11 @@ function createData(
     impactMoyenFoyer_plf, impactMoyenFoyer_reforme,
     impotMoyenFoyer, impotMoyenFoyer_plf, impotMoyenFoyer_reforme,
     recettesEtat, recettesEtat_plf, recettesEtat_reforme,
-    revenuFiscalDeReference,
+    frontiereDecile,
   };
 }
 
-
-function create_from_deciles(index, decile) {
-  // source (2016) http://www.senat.fr/rap/l16-140-211/l16-140-2111.pdf
-  const revenusFiscauxDeReference = [
-    3569, 9053, 12811,
-    16167, 19300, 23895,
-    29520, 37720, 52716,
-    "∞",
-  ];
-
+function create_from_deciles(index, decile, frontiereDecile) {
   var impactMoyenFoyer_plf = decile.avant ? Math.round((decile.plf / decile.avant - 1) * 100) : "-";
   var impactMoyenFoyer_reforme = decile.avant ? Math.round((decile.apres / decile.avant - 1) * 100) : "-";
   var impotMoyenFoyer = Math.round(decile.avant / decile.poids);
@@ -92,14 +83,15 @@ function create_from_deciles(index, decile) {
   var recettesEtat = Math.round(decile.avant / 10000000) / 100;
   var recettesEtat_plf = Math.round(decile.plf / 10000000) / 100;
   var recettesEtat_reforme = Math.round(decile.apres / 10000000) / 100;
+  var frontiere = Math.round(frontiereDecile)
 
   return createData(
     index + 1,
-    revenusFiscauxDeReference[index],
+    frontiere,
     impactMoyenFoyer_plf, impactMoyenFoyer_reforme,
     impotMoyenFoyer, impotMoyenFoyer_plf, impotMoyenFoyer_reforme,
     recettesEtat, recettesEtat_plf, recettesEtat_reforme
-  ); // Les recettes de l'Etat doivent être après réforme?
+  );
 }
 
 function imageDecile(id) {
@@ -111,8 +103,9 @@ function imageDecile(id) {
 }
 
 function SimpopTableurInfosDeciles({ classes, deciles, frontieres_deciles }) {
-  const rows = deciles.map((currElement, index) => create_from_deciles(index, currElement));
+  const rows = deciles.map((currElement, index) => create_from_deciles(index, currElement, frontieres_deciles[index]));
   const NON_APPLICABLE = "—";
+
   return (
     <Table>
       <TableHead>
@@ -144,7 +137,7 @@ function SimpopTableurInfosDeciles({ classes, deciles, frontieres_deciles }) {
               {imageDecile(row.decile)}
             </TableCell>
             <TableCell classes={{root: classes.cellStyle}}>
-              {row.revenuFiscalDeReference}€/an
+              {row.frontiereDecile}€/an
             </TableCell>
             <TableCell classes={{root: classes.cellStyle}}>
               <span style={styles.plf}>

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -138,7 +138,7 @@ function SimpopTableurInfosDeciles({ classes, deciles, frontieres_deciles }) {
               {imageDecile(row.decile)}
             </TableCell>
             <TableCell classes={{root: classes.cellStyle}}>
-              {row.frontiereDecile}€/an
+              &#10877;&nbsp;{row.frontiereDecile}€/an
             </TableCell>
             <TableCell classes={{root: classes.cellStyle}}>
               <span style={styles.plf}>

--- a/components/carte-etat/simpop-tableur-infos-deciles.jsx
+++ b/components/carte-etat/simpop-tableur-infos-deciles.jsx
@@ -133,7 +133,7 @@ function SimpopTableurInfosDeciles({ classes, deciles, frontieres_deciles }) {
           </TableCell>
           <TableCell classes={{root: classes.cellStyle}}>
             <b>Recettes pour l&apos;État</b>
-            <br/>(en Millions d'Euros)
+            <br/>(en Millions d&apos;Euros)
           </TableCell>
         </TableRow>
       </TableHead>

--- a/components/cartes-impact/impact-component.jsx
+++ b/components/cartes-impact/impact-component.jsx
@@ -49,6 +49,7 @@ ImpactComponent.propTypes = {
   isUserLogged: PropTypes.bool.isRequired,
   totalPop: PropTypes.shape({
     deciles: PropTypes.arrayOf(PropTypes.shape()),
+    frontieres_deciles: PropTypes.arrayOf(PropTypes.number),
     total: PropTypes.shape(),
   }).isRequired,
 };

--- a/components/simulation-menu/config.js
+++ b/components/simulation-menu/config.js
@@ -29,7 +29,7 @@ const config = {
     {
       Icon: AddCircleOutlineIcon,
       action: showAddCasTypesPopin,
-      disabled: false,
+      disabled: true,
       key: "cas_types",
       label: "Ajouter un cas type",
       shortLabel: "Cas type",

--- a/components/simulation-menu/simulation-outils-menu.jsx
+++ b/components/simulation-menu/simulation-outils-menu.jsx
@@ -47,6 +47,7 @@ class SimulationOutilsMenu extends PureComponent {
     const menuProps = { classes: { paper: classes.menuPaper } };
     return (
       <MUIDropdownMenu
+        id="cas-types-menu"
         menuProps={menuProps}
         renderMenu={this.renderMenuListItems}
         size="medium"
@@ -54,6 +55,7 @@ class SimulationOutilsMenu extends PureComponent {
         onClick={() => itemMenuClickHandler(selected)}>
         {showMobileView && selected.Icon && <selected.Icon />}
         {showMobileView && selected.Icon && " "}
+        &nbsp;
         {(showMobileView && selected.shortLabel) || selected.label}
       </MUIDropdownMenu>
     );

--- a/redux/actions/tests/popin-cas-types-add.js
+++ b/redux/actions/tests/popin-cas-types-add.js
@@ -10,7 +10,7 @@ describe("components | actions | showAddCasTypesPopin", () => {
       Router.push.mockClear();
     });
 
-    it("doit avoir appeler la methode push du Router a l'ouverture de la popin 'en savoir plus'", () => {
+    it("doit avoir appele la methode push du Router a l'ouverture de la popin 'en savoir plus'", () => {
       const expected = { type: null };
       const result = showAddCasTypesPopin();
       expect(result).toStrictEqual(expected);

--- a/redux/reducers/reforme.js
+++ b/redux/reducers/reforme.js
@@ -95,7 +95,6 @@ const reforme = (state = DEFAULT_STATE, action) => {
   case "onUpdateReformePlafond":
     return updateGenerique(nextState, name, value);
   case "onResetVarArticle":
-    //  console.log("coucou j'ai cliqué");
     return cloneDeep(REFORME_PLF_DEFAULT_STATE);
   default:
     return nextState;

--- a/redux/reducers/total-pop.js
+++ b/redux/reducers/total-pop.js
@@ -84,8 +84,6 @@ const DEFAULT_STATE = {
 
 
 const totalPop = (state = DEFAULT_STATE, action) => {
-  console.log("total-pop")
-  console.log(action)
   switch (action.type) {
   case "onSimPopFetchResult":
     return {

--- a/redux/reducers/total-pop.js
+++ b/redux/reducers/total-pop.js
@@ -82,7 +82,10 @@ const DEFAULT_STATE = {
   ]
 };
 
+
 const totalPop = (state = DEFAULT_STATE, action) => {
+  console.log("total-pop")
+  console.log(action)
   switch (action.type) {
   case "onSimPopFetchResult":
     return {

--- a/redux/reducers/total-pop.js
+++ b/redux/reducers/total-pop.js
@@ -87,6 +87,7 @@ const totalPop = (state = DEFAULT_STATE, action) => {
   case "onSimPopFetchResult":
     return {
       deciles: get(action, "data.deciles"),
+      frontieres_deciles: get(action, "data.frontieres_deciles"),
       total: get(action, "data.total"),
     };
   default:


### PR DESCRIPTION
Utilise `frontieres_deciles` de l'endpoint serveur `/calculate/simpop` pour alimenter la colonne `Revenu fiscal de référence` du tableau de déciles.

---
Parmi les éléments d'interface à vérifier, il y a :
- [x] En cliquant sur `Menu` en haut à gauche, un footer présente en quelques lignes à gauche LexImpact, et propose trois boutons à droite (les CGU, les mentions légales, un mailto). Il est pimpé et UI friendly.
- [x] Le Header est pimpé avec au centre (Open ou LexImpact POP), sur la droite le bouton clé de connexion, ou mon compte.
- [x] L'article présente les fonctionnalité ci-dessous :
    - [x] L'article 197 I.1 ; 2. ; 3. ; 4. ;
    - [x] Les variables de l'ensemble des alinéas sont actives ;
    - [x] Dans le I.1. on peut ajouter, enlever des tranches.
- [x] La partie Output est composée de 6 cas types par défaut.
- [x] Les cas types par défaut présentent les fonctionalités suivantes :
    - [x] Le salaire est modifiable par menu déroulant ;
    - [x] Les têtes changent de façon aléatoire pour plus d'inclusion.

En plus des grandes fonctionnalités ci-dessus, veiller à ce que l'affichage général ne soit pas dégradé visuellement.