### PR TITLE
Ajout admin Sénat à la popin de connexion

### DIFF
--- a/components/connexion/config.json
+++ b/components/connexion/config.json
@@ -33,6 +33,12 @@
       "disabled": true,
       "label": "Collaborat·eur·rice Sénat",
       "domains": []
+    },
+    "senatadmin": {
+      "default": false,
+      "disabled": false,
+      "label": "Administrat·eur·rice Sénat",
+      "domains": ["@senat.fr"]
     }
   }
 }

--- a/components/connexion/form/tests/__snapshots__/roles-input.test.jsx.snap
+++ b/components/connexion/form/tests/__snapshots__/roles-input.test.jsx.snap
@@ -51,6 +51,14 @@ exports[`components | connexion | roles-input snapshot doit correspondre avec le
         "domains": Array [],
         "label": "Sénat·eur·rice",
       },
+      "senatadmin": Object {
+        "default": false,
+        "disabled": false,
+        "domains": Array [
+          "@senat.fr",
+        ],
+        "label": "Administrat·eur·rice Sénat",
+      },
       "senatcollab": Object {
         "default": false,
         "disabled": true,

--- a/components/connexion/tests/utils.test.js
+++ b/components/connexion/tests/utils.test.js
@@ -169,6 +169,12 @@ describe("components | connexion | utils", () => {
           domains: [],
           label: "Collaborat·eur·rice Sénat",
         },
+        senatadmin: {
+          default: false,
+          disabled: false,
+          domains: ["@senat.fr"],
+          label: "Administrat·eur·rice Sénat"
+        }
       };
       expect(given).toStrictEqual(AVAILABLE_ROLES);
     });


### PR DESCRIPTION
Ajoute un champ à la popin de connexion pour les administratrices et administrateurs du Sénat.
Le champ est actif et relié au nom de domaine `senat.fr`.

> Le bug de coloration sur le `Je suis` est toujours présent. Il semble s'activer en mode `focused`.
---

- [ ] En cliquant sur `Menu` en haut à gauche, un footer présente en quelques lignes à gauche LexImpact, et propose trois boutons à droite (les CGU, les mentions légales, un mailto). Il est pimpé et UI friendly.
- [ ] Le Header est pimpé avec au centre (Open ou LexImpact POP), sur la droite le bouton clé de connexion, ou mon compte.
- [ ] L'article présente les fonctionnalité ci-dessous :
    - [ ] L'article 197 I.1 ; 2. ; 3. ; 4. ;
    - [ ] Les variables de l'ensemble des alinéas sont actives ;
    - [ ] Dans le I.1. on peut ajouter, enlever des tranches.
- [ ] La partie Output est composée de 6 cas types par défaut.
- [ ] Les cas types par défaut présentent les fonctionalités suivantes :
    - [ ] Le salaire est modifiable par menu déroulant ;
    - [ ] Les têtes changent de façon aléatoire pour plus d'inclusion.

En plus des grandes fonctionnalités ci-dessus, veiller à ce que l'affichage général ne soit pas dégradé visuellement.