### PR TITLE
Corrige les espaces entre informations présentées à l'usager

### DIFF
--- a/components/articles-inputs/base-input-output/base-input-output-component.jsx
+++ b/components/articles-inputs/base-input-output/base-input-output-component.jsx
@@ -18,7 +18,7 @@ const BaseInputOutputComponent = ({
 }) => (
   <Fragment>
     <OutputField style={Math.abs(baseValue-plfValue) < 0.001 ? outputFieldStyleNonBarre : outputFieldStyle} value={formatMilliers(baseValue)} />
-    {Math.abs(baseValue-plfValue) < 0.001 ? "" : <OutputField style={plfFieldStyle} value={formatMilliers(plfValue)} />}
+    {Math.abs(baseValue-plfValue) < 0.001 ? " " : <OutputField style={plfFieldStyle} value={formatMilliers(plfValue)} />}
     <InputField
       name={name}
       style={inputFieldStyle}

--- a/components/articles-inputs/formula-output/formula-output-component.jsx
+++ b/components/articles-inputs/formula-output/formula-output-component.jsx
@@ -9,7 +9,7 @@ const FormulaOutputComponent = ({
 }) => (
   <Fragment>
     <OutputField style={Math.abs(baseValue-plfValue) < 0.001 ? style.VarCodeexistantNonBarre : style.VarCodeexistant} value={formatMilliers(baseValue)} />
-    {Math.abs(baseValue-plfValue) < 0.001 ? "" : <OutputField style={style.VarPLF} value={formatMilliers(plfValue)} />}
+    {Math.abs(baseValue-plfValue) < 0.001 ? " " : <OutputField style={style.VarPLF} value={formatMilliers(plfValue)} />}
     <OutputField style={style.VarCodeNew} value={formatMilliers(newValue)} />
   </Fragment>
 );

--- a/components/articles/article-alinea-2/article-alinea-2-component.jsx
+++ b/components/articles/article-alinea-2/article-alinea-2-component.jsx
@@ -58,7 +58,7 @@ class Alinea2 extends PureComponent {
             2. La réduction d&apos;impôt résultant de l&apos;application du
             quotient familial ne peut excéder
             {baseOutputInput("plafond_qf.maries_ou_pacses")}
-€ par demi-part ou
+            € par demi-part ou
             la moitié de cette somme par quart de part s&apos;ajoutant à une
             part pour les contribuables célibataires, divorcés, veufs ou soumis
             à l&apos;imposition distincte prévue au 4 de l&apos;article 6 et à
@@ -70,7 +70,7 @@ class Alinea2 extends PureComponent {
             part accordée au titre du premier enfant à charge est limitée à
             {baseOutputInput("plafond_qf.celib_enf")}
             {" "}
-€ Lorsque les
+            € Lorsque les
             contribuables entretiennent uniquement des enfants dont la charge
             est réputée également partagée entre l&apos;un et l&apos;autre des
             parents, la réduction d&apos;impôt correspondant à la demi-part
@@ -99,7 +99,7 @@ class Alinea2 extends PureComponent {
             en application du I de l&apos;article 194 ont droit à une réduction
             d&apos;impôt égale à
             {baseOutputInput("plafond_qf.reduc_postplafond_veuf")}
-€ pour cette
+            € pour cette
             part supplémentaire lorsque la réduction de leur cotisation
             d&apos;impôt est plafonnée en application du premier alinéa du
             présent 2. Cette réduction d&apos;impôt ne peut toutefois excéder

--- a/components/articles/article-alinea-3/article-alinea-3-component.jsx
+++ b/components/articles/article-alinea-3/article-alinea-3-component.jsx
@@ -85,7 +85,7 @@ class ArticleAlinea3 extends PureComponent {
             <Icon icon={classicalBuilding} />
             <span>
               La modification des paramètres de la décote outre-mer est
-              actuellement uniquement prise en compte pour le calcul de l'impôt des
+              actuellement uniquement prise en compte pour le calcul de l&apos;impôt des
               foyers fiscaux types.
             </span>
           </div>
@@ -96,7 +96,7 @@ class ArticleAlinea3 extends PureComponent {
             {baseOutputInput("plafond_qf.abat_dom.taux_GuadMarReu")}
             %, dans la limite de
             {baseOutputInput("plafond_qf.abat_dom.plaf_GuadMarReu")}
-€ pour les
+            € pour les
             contribuables domiciliés dans les départements de la Guadeloupe, de
             la Martinique et de la Réunion ; cette réduction est égale à
             {" "}

--- a/components/articles/article-alinea-4a/article-alinea-4a-component.jsx
+++ b/components/articles/article-alinea-4a/article-alinea-4a-component.jsx
@@ -78,22 +78,22 @@ class Alinea4a extends PureComponent {
             de la différence entre
             {" "}
             {baseOutputInput("decote.seuil_celib")}
-€ et
+            € et
             les
             {" "}
             <OutputField style={style.VarCodeexistant} value="trois quarts" />
             {" "}
-[
+            [
             {baseOutputInput("decote.taux")}
             %] de son montant pour les contribuables célibataires, divorcés ou
             veufs et de la différence entre
             {baseOutputInput("decote.seuil_couple")}
             {" "}
-€ et les
+            € et les
             {" "}
             <OutputField style={style.VarCodeexistant} value="trois quarts" />
             {" "}
-[
+            [
             {formulaOutputInput("decote.taux")}
             %] de son montant pour les contribuables soumis à imposition
             commune.

--- a/components/articles/article-alinea-4b/article-alinea-4b-component.jsx
+++ b/components/articles/article-alinea-4b/article-alinea-4b-component.jsx
@@ -64,7 +64,7 @@ class Alinea4b extends PureComponent {
         {" "}
         {baseOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil2")}
         {" "}
-€,
+        €,
         pour la première part de quotient familial des personnes célibataires,
         veuves ou divorcées, et à
         {formulaOutputInput(
@@ -111,7 +111,7 @@ class Alinea4b extends PureComponent {
         {" "}
         {baseOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil1")}
         {" "}
-€,
+        €,
         pour la première part de quotient familial des personnes célibataires,
         veuves ou divorcées, ou
         {" "}
@@ -126,7 +126,7 @@ class Alinea4b extends PureComponent {
         {baseOutputInput("plafond_qf.reduction_ss_condition_revenus.taux")}
         % multiplié par le rapport entre :
         <br />
-– au numérateur, la différence entre
+        – au numérateur, la différence entre
         {" "}
         {formulaOutputInput("plafond_qf.reduction_ss_condition_revenus.seuil2")}
         €, pour les personnes célibataires, veuves ou divorcées, ou
@@ -139,7 +139,7 @@ class Alinea4b extends PureComponent {
         alinéa, et le montant des revenus mentionnés au troisième alinéa du
         présent b, et ;
         <br />
-– au dénominateur,
+        – au dénominateur,
         {" "}
         {formulaOutputInputCombiLin(
           "plafond_qf.reduction_ss_condition_revenus.seuil2",

--- a/components/articles/article-header.jsx
+++ b/components/articles/article-header.jsx
@@ -156,7 +156,7 @@ avec les paramètres du&nbsp;:
                   onClick={this.handleClickExistant}>
                   <span>-</span>
                   <span className={classes.styleCodeExistant}>
-                    &nbsp;code existant
+                    code existant
                   </span>
                 </MenuItem>
               </Menu>

--- a/components/articles/article-header.jsx
+++ b/components/articles/article-header.jsx
@@ -142,7 +142,7 @@ class ArticleHeader extends PureComponent {
                     Réinitialiser mon amendement
                     <br />
                     {" "}
-avec les paramètres du&nbsp;:
+                    avec les paramètres du&nbsp;:
                   </span>
                 </div>
                 <MenuItem

--- a/components/articles/articles-component.jsx
+++ b/components/articles/articles-component.jsx
@@ -200,7 +200,7 @@ class ArticlesComponent extends React.Component {
             value={makeNumberGoodLooking(baseValuet)}
           />
           {/* rouge */}
-          {Math.abs(baseValuet-plfValuet) < 0.001 ? "" : <OutputField style={style.VarPLF} value={makeNumberGoodLooking(plfValuet)} />}
+          {Math.abs(baseValuet-plfValuet) < 0.001 ? " " : <OutputField style={style.VarPLF} value={makeNumberGoodLooking(plfValuet)} />}
           {/* bleu editable (pourcentage) */}
           <InputField
             name={`taux${i - 1}`}
@@ -238,7 +238,7 @@ class ArticlesComponent extends React.Component {
           value={makeNumberGoodLooking(baseValuet)}
         />
         {/* rouge */}
-        {Math.abs(baseValuet-plfValuet) < 0.001 ? "" : <OutputField style={style.VarPLF} value={makeNumberGoodLooking(plfValuet)} />}
+        {Math.abs(baseValuet-plfValuet) < 0.001 ? " " : <OutputField style={style.VarPLF} value={makeNumberGoodLooking(plfValuet)} />}
         <InputField
           name={`taux${i - 1}`}
           style={style.InputTaux}

--- a/components/carte-etat/carte-etat-component.jsx
+++ b/components/carte-etat/carte-etat-component.jsx
@@ -184,7 +184,7 @@ class CarteEtat extends PureComponent {
                     <br />
                     {" "}
 Estimation à partir des données de l&apos;Enquête
-                    Revenus Fiscaux et Sociaux (ERFS-FPR 2014) de l&apos;Insee.
+                    Revenus Fiscaux et Sociaux (ERFS-FPR) de l&apos;Insee.
                   </Typography>
                 </div>
               ),

--- a/components/cartes-impact/gagnants-perdants/gagnants-perdants-component.jsx
+++ b/components/cartes-impact/gagnants-perdants/gagnants-perdants-component.jsx
@@ -496,7 +496,7 @@ class GagnantsPerdantsCard extends PureComponent {
             * Chiffrages indicatifs.
             <br />
             {" "}
-Données ERFS-FPR 2014 (Insee).
+            Données ERFS-FPR (Insee).
           </Typography>
         </>
         )])}

--- a/components/cartes-impact/simple-card/impact-impots.jsx
+++ b/components/cartes-impact/simple-card/impact-impots.jsx
@@ -64,7 +64,7 @@ class SimpleCardImpactImpots extends PureComponent {
             variant="h3">
             {formatMilliers(-resultats.avant)}
           </Typography>
-
+          {" "}
           <RedTooltip
             className={classes.stylePLF}
             key="gain"


### PR DESCRIPTION
* Dans le menu de réinitialisation des amendements, supprime cet espace surligné avant `code existant` :
<img width="245" alt="Screen Shot 2019-10-16 at 17 36 00" src="https://user-images.githubusercontent.com/6567910/66942796-1f9ade00-f04a-11e9-81e5-87ad807571b6.png">

* Dans les articles, ajoute un espace entre avant/plf/après et avant/après (éditable ou pas) lorsqu'il n'y en avait pas comme dans cet exemple :
<img width="228" alt="Screen Shot 2019-10-16 at 18 28 16" src="https://user-images.githubusercontent.com/6567910/66942868-4d802280-f04a-11e9-92e7-4094c9e9dca9.png">

* Dans les cas types, ajoute un espace entre avant/plf. Précédemment, nous avions :
<img width="455" alt="Screen Shot 2019-10-16 at 18 05 44" src="https://user-images.githubusercontent.com/6567910/66942857-46f1ab00-f04a-11e9-8f16-0f8a34f38958.png">

* Dans la carte état et la carte de nombre de foyers touchés, n'indique plus l'année du millésime des données qui peut prêter à confusion.

---
Parmi les éléments d'interface à vérifier, il y a :
- [x] En cliquant sur `Menu` en haut à gauche, un footer présente en quelques lignes à gauche LexImpact, et propose trois boutons à droite (les CGU, les mentions légales, un mailto). Il est pimpé et UI friendly.
- [x] Le Header est pimpé avec au centre (Open ou LexImpact POP), sur la droite le bouton clé de connexion, ou mon compte.
- [x] L'article présente les fonctionnalité ci-dessous :
    - [x] L'article 197 I.1 ; 2. ; 3. ; 4. ;
    - [x] Les variables de l'ensemble des alinéas sont actives ;
    - [x] Dans le I.1. on peut ajouter, enlever des tranches.
- [x] La partie Output est composée de 6 cas types par défaut.
- [x] Les cas types par défaut présentent les fonctionalités suivantes :
    - [x] Le salaire est modifiable par menu déroulant ;
    - [x] Les têtes changent de façon aléatoire pour plus d'inclusion.