### PR TITLE
Met à jour la liste des domaines admin Sénat

### DIFF
--- a/components/connexion/config.json
+++ b/components/connexion/config.json
@@ -38,7 +38,7 @@
       "default": false,
       "disabled": false,
       "label": "Administrat·eur·rice Sénat",
-      "domains": ["@senat.fr"]
+      "domains": ["@senat.fr", "@republicains.senat.fr", "@soc.senat.fr", "@uc.senat.fr", "@rdse.senat.fr", "@lrem.senat.fr"]
     }
   }
 }

--- a/components/connexion/form/tests/__snapshots__/roles-input.test.jsx.snap
+++ b/components/connexion/form/tests/__snapshots__/roles-input.test.jsx.snap
@@ -56,6 +56,11 @@ exports[`components | connexion | roles-input snapshot doit correspondre avec le
         "disabled": false,
         "domains": Array [
           "@senat.fr",
+          "@republicains.senat.fr",
+          "@soc.senat.fr",
+          "@uc.senat.fr",
+          "@rdse.senat.fr",
+          "@lrem.senat.fr",
         ],
         "label": "Administrat·eur·rice Sénat",
       },

--- a/components/connexion/tests/utils.test.js
+++ b/components/connexion/tests/utils.test.js
@@ -172,7 +172,7 @@ describe("components | connexion | utils", () => {
         senatadmin: {
           default: false,
           disabled: false,
-          domains: ["@senat.fr"],
+          domains: ["@senat.fr", "@republicains.senat.fr", "@soc.senat.fr", "@uc.senat.fr", "@rdse.senat.fr", "@lrem.senat.fr"],
           label: "Administrat·eur·rice Sénat"
         }
       };


### PR DESCRIPTION
Suite à la démo, ajoute la liste des sous-domaines Sénat associés au profil administrat·eur·rice Sénat.
