### PR TITLE
Corrige les warnings et supprime le toggle réfaction foyer modeste 

### DIFF
--- a/components/articles/article-alinea-4b/article-alinea-4b-component.jsx
+++ b/components/articles/article-alinea-4b/article-alinea-4b-component.jsx
@@ -161,19 +161,6 @@ class Alinea4b extends PureComponent {
         année dans la même proportion que la limite supérieure de la première
         tranche du barème de l&apos;impôt sur le revenu. Les montants obtenus
         sont arrondis, s&apos;il y a lieu, à l&apos;euro supérieur.
-        <StyledFormControlLabel
-          disabled
-          control={(
-            <Switch
-              // checked={this.state.checkedB}
-              // onChange={this.handleChange("checkedB")}
-              // value="checkedB"
-              color="secondary"
-            />
-          )}
-          label="Supprimer la réfaction foyers modestes"
-          // Mettre les variables de l'amendement à 0 quand le switch est passé.
-        />
       </Typography>
     );
   }

--- a/components/consulter-expert/consulter-expert-component.jsx
+++ b/components/consulter-expert/consulter-expert-component.jsx
@@ -87,9 +87,10 @@ class ConsulterExpertCard extends PureComponent {
   render() {
     const {
       classes,
-      expandArticlePanelHandler,
-      isPanelExpanded,
       onRemoveConsulterExpert,
+      isPanelExpanded,
+      onExpandPanel,
+      
     } = this.props;
 
     return (
@@ -115,7 +116,7 @@ class ConsulterExpertCard extends PureComponent {
               <ExpansionPanel
                 classes={{ root: classes.styleExpansionPanel }}
                 expanded={isPanelExpanded}
-                onChange={expandArticlePanelHandler}>
+                onChange={onExpandPanel}>
                 <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
                   <Typography className={classes.subtitleEnSavoirPlus}>
                     En savoir plus
@@ -164,8 +165,8 @@ class ConsulterExpertCard extends PureComponent {
 ConsulterExpertCard.propTypes = {
   classes: PropTypes.shape().isRequired,
   onRemoveConsulterExpert: PropTypes.func.isRequired,
-  isPanelExpanded: PropTypes.shape().isRequired,
-  expandArticlePanelHandler: PropTypes.shape().isRequired,
+  isPanelExpanded: PropTypes.bool.isRequired,
+  onExpandPanel: PropTypes.func.isRequired,
 };
 
 export default withStyles(styles)(ConsulterExpertCard);

--- a/components/consulter-expert/index.js
+++ b/components/consulter-expert/index.js
@@ -1,12 +1,20 @@
 import { connect } from "react-redux";
 
-import { closeConsulterExpert } from "../../redux/actions";
+import { closeConsulterExpert, expandArticlePanel } from "../../redux/actions";
 import ConsulterExpertCard from "./consulter-expert-component";
 
-const mapStateToProps = null;
+const PANEL_NAME = "consulter_expert";
+
+const mapStateToProps  = ({ currentExpandedArticlePanel }) => {
+  const isPanelExpanded = currentExpandedArticlePanel === PANEL_NAME;
+  return {
+    isPanelExpanded,
+  };
+};
 
 const mapDispatchToProps = dispatch => ({
   onRemoveConsulterExpert: () => dispatch(closeConsulterExpert()),
+  onExpandPanel: () => dispatch(expandArticlePanel(PANEL_NAME)),
 });
 
 export default connect(

--- a/components/simulation-menu/config.js
+++ b/components/simulation-menu/config.js
@@ -12,6 +12,7 @@ const config = {
       Icon: ShareIcon,
       /* TODO: creer une action redux pour cet item du menu */
       action: () => ({ type: "undefined" }),
+      disabled: true,
       key: "simpop-share-button",
       label: "Partager",
       shortLabel: "Partager",
@@ -20,6 +21,7 @@ const config = {
       Icon: ViewQuiltIcon,
       /* TODO: creer une action redux pour cet item du menu */
       action: () => ({ type: "undefined" }),
+      disabled: true,
       key: "simpop-workspace-button",
       label: "Espace de travail",
       shortLabel: "Espace de travail",


### PR DESCRIPTION
* Propose de supprimer le toggle suivant sachant qu'il est inactif et en doublon avec l'abrogation apportée par le PLF : 
<img width="268" alt="Screen Shot 2019-10-28 at 11 41 20" src="https://user-images.githubusercontent.com/6567910/67686552-2c4afa80-f997-11e9-9943-f42165985d46.png">


* Corrige les warnings suivants :
  ```js
  index.js:2178 Warning: Failed prop type: The prop `isPanelExpanded` is marked as required in `ConsulterExpertCard`, but its value is `undefined`.
    in ConsulterExpertCard (created by WithStyles(ConsulterExpertCard))
  ...
  index.js:2178 Warning: Failed prop type: The prop `expandArticlePanelHandler` is marked as   required in `ConsulterExpertCard`, but its value is `undefined`.
    in ConsulterExpertCard (created by WithStyles(ConsulterExpertCard))
  ```

🌸 Il ne reste plus de warning en console.

Néanmoins l'expansion panel de `ConsulterExpertCard` reste lié aux expansion panels des articles : 
➕ Avec cette PR, ConsulterExpert dispose maintenant de son propre property-state mapping et dispatch en cas d'expansion du panel 
➖ mais il reste calé sur le code des expansion panels d'articles pour la gestion des effets de l'action d'expansion (redux actions et reducers). Cela a pour effet que le ConsulterExpert agit comme les articles : si un article est étendu, le consulter expert est replié et inversement.

---
Parmi les éléments d'interface à vérifier, il y a :
- [x] En cliquant sur `Menu` en haut à gauche, un footer présente en quelques lignes à gauche LexImpact, et propose trois boutons à droite (les CGU, les mentions légales, un mailto). Il est pimpé et UI friendly.
- [x] Le Header est pimpé avec au centre (Open ou LexImpact POP), sur la droite le bouton clé de connexion, ou mon compte.
- [x] L'article présente les fonctionnalité ci-dessous :
    - [x] L'article 197 I.1 ; 2. ; 3. ; 4. ;
    - [x] Les variables de l'ensemble des alinéas sont actives ;
    - [x] Dans le I.1. on peut ajouter, enlever des tranches.
- [x] La partie Output est composée de 6 cas types par défaut.
- [x] Les cas types par défaut présentent les fonctionalités suivantes :
    - [x] Le salaire est modifiable par menu déroulant ;
    - [x] Les têtes changent de façon aléatoire pour plus d'inclusion.

En plus des grandes fonctionnalités ci-dessus, veiller à ce que l'affichage général ne soit pas dégradé visuellement.