### PR TITLE
Migration de beta.gouv.fr vers an.fr

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ceci est le code source de l'interface utilisateur de LexImpact.
 LexImpact permet aux administrations, aux parlementaires et à la société civile de simuler l'impact _ex ante_ des réformes au système socio-fiscal.
 * [Appels à candidatures](https://entrepreneur-interet-general.etalab.gouv.fr/defis/2019/leximpact.html)
 * [Fiche produit](https://beta.gouv.fr/startups/leximpact.html)
-* [LexImpact Beta](https://leximpact.beta.gouv.fr)
+* [LexImpact](https://leximpact.an.fr)
 
 LexImpact est constitué de deux parties :
 
@@ -22,7 +22,7 @@ This is the source code of LexImpact user interface.
 LexImpact allows civil servants, policy makers and citizens to simulate the _ex ante_ impact of a reform to a country's tax-benefit system.
 * [Call for candidates (FR)](https://entrepreneur-interet-general.etalab.gouv.fr/defis/2019/leximpact.html)
 * [Elevator pitch (FR)](https://beta.gouv.fr/startups/leximpact.html)
-* [LexImpact Beta](https://leximpact.beta.gouv.fr)
+* [LexImpact](https://leximpact.an.fr)
 
 LexImpact has two components:
 
@@ -41,7 +41,7 @@ npm run dev
 A file name `.env` is necessary for the client to work properly. The file `.env.example` can be copied into it.
 
 Here ate the environment variables that you have to set:
-- `API_URL`: leximpact-client is just a web interface that does not do computations by itself, but needs to be provided a working [leximpact-server](https://github.com/betagouv/leximpact-server/) Web API to fetch results. As of v`1.0.0`, a working API example can be found on: https://api.leximpact.beta.gouv.fr
+- `API_URL`: leximpact-client is just a web interface that does not do computations by itself, but needs to be provided a working [leximpact-server](https://github.com/betagouv/leximpact-server/) Web API to fetch results. As of v`1.0.0`, a working API example can be found on: https://api.leximpact.an.fr
 - `PORT`: describes the port that the client will be setup to (e.g. the website will be accessible from http://127.0.0.1:<PORT> if the client is run locally). If ommited, defaults to `9001`
 
 

--- a/components/en-savoir-plus/en-savoir-plus-component.jsx
+++ b/components/en-savoir-plus/en-savoir-plus-component.jsx
@@ -105,13 +105,13 @@ class EnSavoiPlusComponent extends PureComponent {
                 <Button
                   fullWidth
                   color="inherit"
-                  href="mailto:contact@leximpact.beta.gouv.fr"
+                  href="mailto:leximpact@an.fr"
                   size="large"
                   variant="outlined">
                   Une question ? Un bug ? Un avis ?
                 </Button>
                 <p className={classes.pAdresseMail}>
-                  Écrivez-nous à contact@leximpact.beta.gouv.fr !
+                  Écrivez-nous à leximpact@an.fr !
                 </p>
               </div>
             </div>

--- a/components/en-savoir-plus/tests/__snapshots__/en-savoir-plus-component.test.jsx.snap
+++ b/components/en-savoir-plus/tests/__snapshots__/en-savoir-plus-component.test.jsx.snap
@@ -88,7 +88,7 @@ exports[`components | en-savoir-plus-component snapshot doit correspondre avec l
           <WithStyles(Button)
             color="inherit"
             fullWidth={true}
-            href="mailto:contact@leximpact.beta.gouv.fr"
+            href="mailto:leximpact@an.fr"
             size="large"
             variant="outlined"
           >
@@ -97,7 +97,7 @@ exports[`components | en-savoir-plus-component snapshot doit correspondre avec l
           <p
             className="EnSavoiPlusComponent-pAdresseMail-7"
           >
-            Écrivez-nous à contact@leximpact.beta.gouv.fr !
+            Écrivez-nous à leximpact@an.fr !
           </p>
         </div>
       </div>

--- a/components/mentions-legales/texte-mentions-legales.jsx
+++ b/components/mentions-legales/texte-mentions-legales.jsx
@@ -21,11 +21,9 @@ function MyComponent({ classes }) {
       <hr />
 
       <p>
-        Incubateur de services numériques (beta.gouv.fr)
-        <br />
-        de la Direction interministérielle du numérique (DINUM).
+        Equipe Leximpact de L'Assemblée nationale
       </p>
-      <p>20, avenue de Ségur - 75007 Paris.</p>
+      <p>126, rue de l'Université - 75007 Paris.</p>
 
       <div className={classes.espaceVide} />
 
@@ -33,10 +31,10 @@ function MyComponent({ classes }) {
       <hr />
 
       <p>
-        Directeur de la publication : Directeur interministériel du numérique.
+        Directeur de la publication : Secrétaire général de l'Assemblée nationale.
       </p>
 
-      <p>Nadi Bou Hanna</p>
+      <p>Michel Moreau</p>
 
       <div className={classes.espaceVide} />
 


### PR DESCRIPTION
toutes les références sont updatées de beta.gouv.fr vers an.fr

On a également changé les mentions légales, dont le directeur de publication