### PR TITLE
Ajouter fichier mailjet txt

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,6 +22,9 @@ async function start() {
     !!! NE PAS RE-AGENCER
 
   ------------------------------------ */
+  server.get("/bbbc03c2d698ea7ec1194fab549115f1.txt", (req, res) => {
+    res.set("Content-Type", "text/plain").sendStatus(200);
+  });
   server.use("/", express.static(path.join(__dirname, "public")));
   server.use("/static", express.static(path.join(__dirname, "static")));
   // Ouverture de la popin de confirmation de connexion


### PR DESCRIPTION
Nous avons besoin d'indiquer à Mailjet que nous sommes bien le dépositaire du domaine via un fichier txt.