### PR TITLE
Vider fichier mailjet (2ème essai)

### DIFF
--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@ async function start() {
 
   ------------------------------------ */
   server.get("/bbbc03c2d698ea7ec1194fab549115f1.txt", (req, res) => {
-    res.set("Content-Type", "text/plain").sendStatus(200);
+    res.set("Content-Type", "text/plain").send("");
   });
   server.use("/", express.static(path.join(__dirname, "public")));
   server.use("/static", express.static(path.join(__dirname, "static")));


### PR DESCRIPTION
Renvoyer un simple status 200 ne fonctionne apparement pas. Le contenu doit être une chaîne vide.