### PR TITLE
Intervertir boutons de fermeture et d'édition

### DIFF
--- a/components/cartes-impact/simple-card/simple-card-component.jsx
+++ b/components/cartes-impact/simple-card/simple-card-component.jsx
@@ -24,9 +24,9 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import DoublePalmTreeIcon from "../../icons/double-palm-tree";
-import SimpleCardImpactImpots from "./impact-impots";
+import formatMilliers from "../../utils/format-milliers";
 import GreyTooltip from "./grey-tooltip";
-import formatMilliers from "../../utils/format-milliers"
+import SimpleCardImpactImpots from "./impact-impots";
 
 const RESIDENCE_ITEMS = [
   // Doit correspondre a ceux definis
@@ -170,17 +170,17 @@ class SimpleCard extends React.Component {
         <div className={classes.cardHeaderButtons}>
           <IconButton
             disableRipple
-            aria-label="Delete"
-            classes={{ root: classes.cardEditDeleteButton }}
-            onClick={handleRemoveCasType(index)}>
-            <CloseIcon fontSize="small" />
-          </IconButton>
-          <IconButton
-            disableRipple
             aria-label="Edit"
             classes={{ root: classes.cardEditDeleteButton }}
             onClick={handleShowEditCasTypesPopin(index)}>
             <EditIcon fontSize="small" />
+          </IconButton>
+          <IconButton
+            disableRipple
+            aria-label="Delete"
+            classes={{ root: classes.cardEditDeleteButton }}
+            onClick={handleRemoveCasType(index)}>
+            <CloseIcon fontSize="small" />
           </IconButton>
         </div>
       </div>


### PR DESCRIPTION
A mon avis, si les boutons étaient dans le bon ordre au début, le problème vient d'une propriété CSS `float` ou `flex` qui a été changée quelque part.

Merci de contribuer à leximpact-client !
Parmi les éléments d'interface à vérifier, il y a :
- [x] En cliquant sur `Menu` en haut à gauche, un footer présente en quelques lignes à gauche LexImpact, et propose trois boutons à droite (les CGU, les mentions légales, un mailto). Il est pimpé et UI friendly.
- [x] Le Header est pimpé avec au centre (Open ou LexImpact POP), sur la droite le bouton clé de connexion, ou mon compte.
- [x] L'article présente les fonctionnalité ci-dessous :
    - [x] L'article 197 I.1 ; 2. ; 3. ; 4. ;
    - [x] Les variables de l'ensemble des alinéas sont actives ;
    - [x] Dans le I.1. on peut ajouter, enlever des tranches.
- [x] La partie Output est composée de 6 cas types par défaut.
- [x] Les cas types par défaut présentent les fonctionalités suivantes :
    - [x] Le salaire est modifiable par menu déroulant ;
    - [x] Les têtes changent de façon aléatoire pour plus d'inclusion.

En plus des grandes fonctionnalités ci-dessus, veiller à ce que l'affichage général ne soit pas dégradé visuellement.
